### PR TITLE
chore: align org references for MoonSpineStudio migration

### DIFF
--- a/.github/scripts/notion_sync_core.test.mjs
+++ b/.github/scripts/notion_sync_core.test.mjs
@@ -28,15 +28,15 @@ test('mapNotionStatus resolves blocked and done first', () => {
 });
 
 test('buildGithubItemKey is deterministic', () => {
-  assert.equal(buildGithubItemKey('kafkalm/Bossman', 123), 'kafkalm/Bossman#123');
+  assert.equal(buildGithubItemKey('MoonSpineStudio/Bossman', 123), 'MoonSpineStudio/Bossman#123');
 });
 
 test('buildTaskProperties creates required Notion fields', () => {
   const props = buildTaskProperties({
-    repo: 'kafkalm/Bossman',
+    repo: 'MoonSpineStudio/Bossman',
     number: 77,
     title: 'Test title',
-    url: 'https://github.com/kafkalm/Bossman/issues/77',
+    url: 'https://github.com/MoonSpineStudio/Bossman/issues/77',
     issueState: 'open',
     labels: [{ name: 'type:feature' }, { name: 'prio:p1' }],
     body: 'Estimate: L',
@@ -47,11 +47,11 @@ test('buildTaskProperties creates required Notion fields', () => {
   });
 
   assert.equal(props['GitHub Issue ID'].number, 77);
-  assert.equal(props.Repo.select.name, 'kafkalm/Bossman');
+  assert.equal(props.Repo.select.name, 'MoonSpineStudio/Bossman');
   assert.equal(props.Priority.select.name, 'P1');
   assert.equal(props.Estimate.select.name, 'L');
   assert.equal(props['Work Type'].select.name, 'feature');
-  assert.equal(props['GitHub Item Key'].rich_text[0].text.content, 'kafkalm/Bossman#77');
+  assert.equal(props['GitHub Item Key'].rich_text[0].text.content, 'MoonSpineStudio/Bossman#77');
   assert.equal(props['Created At'].date.start, '2026-02-20T00:00:00.000Z');
   assert.equal(props['Started At'].date.start, '2026-02-20T00:00:00.000Z');
   assert.equal(props['Done At'].date.start, '2026-02-22T12:00:00.000Z');
@@ -64,23 +64,23 @@ test('buildTaskProperties creates required Notion fields', () => {
 
 test('buildPortfolioProjectProperties creates stable project row properties', () => {
   const props = buildPortfolioProjectProperties({
-    repo: 'kafkalm/rougeflipper',
+    repo: 'MoonSpineStudio/rougeflipper',
     syncedAt: '2026-02-27T12:00:00.000Z',
   });
 
   assert.equal(props.Title.title[0].text.content, 'rougeflipper');
-  assert.equal(props['Project Key'].rich_text[0].text.content, 'kafkalm/rougeflipper');
+  assert.equal(props['Project Key'].rich_text[0].text.content, 'MoonSpineStudio/rougeflipper');
   assert.equal(props.Status.select.name, 'Active');
-  assert.equal(props['Repository URL'].url, 'https://github.com/kafkalm/rougeflipper');
+  assert.equal(props['Repository URL'].url, 'https://github.com/MoonSpineStudio/rougeflipper');
   assert.equal(props['Last Synced At'].date.start, '2026-02-27T12:00:00.000Z');
 });
 
 test('buildTaskProperties keeps timeline fields empty for planned open issue', () => {
   const props = buildTaskProperties({
-    repo: 'kafkalm/Bossman',
+    repo: 'MoonSpineStudio/Bossman',
     number: 78,
     title: 'Backlog item',
-    url: 'https://github.com/kafkalm/Bossman/issues/78',
+    url: 'https://github.com/MoonSpineStudio/Bossman/issues/78',
     issueState: 'open',
     labels: [{ name: 'status:backlog' }],
     body: '',
@@ -100,19 +100,19 @@ test('buildTaskProperties keeps timeline fields empty for planned open issue', (
 
 test('buildTaskProperties writes GitHub PR ID when provided', () => {
   const props = buildTaskProperties({
-    repo: 'kafkalm/Bossman',
+    repo: 'MoonSpineStudio/Bossman',
     number: 79,
     title: 'PR linked issue',
-    url: 'https://github.com/kafkalm/Bossman/issues/79',
+    url: 'https://github.com/MoonSpineStudio/Bossman/issues/79',
     issueState: 'open',
     labels: [],
     body: '',
-    prUrl: 'https://github.com/kafkalm/Bossman/pull/100',
+    prUrl: 'https://github.com/MoonSpineStudio/Bossman/pull/100',
     prNumber: 100,
     createdAt: '2026-02-20T00:00:00.000Z',
     syncedAt: '2026-02-23T00:00:00.000Z',
   });
 
   assert.equal(props['GitHub PR ID'].number, 100);
-  assert.equal(props['PR URL'].url, 'https://github.com/kafkalm/Bossman/pull/100');
+  assert.equal(props['PR URL'].url, 'https://github.com/MoonSpineStudio/Bossman/pull/100');
 });

--- a/.github/scripts/pr_issue_link_guard.test.mjs
+++ b/.github/scripts/pr_issue_link_guard.test.mjs
@@ -9,12 +9,12 @@ test('accepts closes keyword with local issue number', () => {
 });
 
 test('accepts closes keyword with cross-repo issue', () => {
-  assert.equal(hasLinkedIssue('Closes kafkalm/rougeflipper#88'), true);
+  assert.equal(hasLinkedIssue('Closes MoonSpineStudio/rougeflipper#88'), true);
 });
 
 test('accepts issue url in body', () => {
   assert.equal(
-    hasLinkedIssue('Tracking issue: https://github.com/kafkalm/rougeflipper/issues/42'),
+    hasLinkedIssue('Tracking issue: https://github.com/MoonSpineStudio/rougeflipper/issues/42'),
     true,
   );
 });

--- a/scripts/onboard_repo_core.test.mjs
+++ b/scripts/onboard_repo_core.test.mjs
@@ -24,7 +24,7 @@ test('normalizeNotionId throws on invalid input', () => {
 });
 
 test('defaultTaskDbName uses repo name suffix', () => {
-  assert.equal(defaultTaskDbName('kafkalm/Bossman'), 'Task Mirror DB - Bossman');
+  assert.equal(defaultTaskDbName('MoonSpineStudio/Bossman'), 'Task Mirror DB - Bossman');
 });
 
 test('buildTaskMirrorProperties contains required keys', () => {
@@ -48,19 +48,19 @@ test('buildTaskMirrorProperties contains required keys', () => {
 });
 
 test('defaultPortfolioTitle uses repo name suffix', () => {
-  assert.equal(defaultPortfolioTitle('kafkalm/rougeflipper'), 'rougeflipper');
+  assert.equal(defaultPortfolioTitle('MoonSpineStudio/rougeflipper'), 'rougeflipper');
 });
 
 test('buildPortfolioProjectProperties creates stable project key row', () => {
   const props = buildPortfolioProjectProperties({
-    repo: 'kafkalm/rougeflipper',
+    repo: 'MoonSpineStudio/rougeflipper',
     syncedAt: '2026-02-27T12:00:00.000Z',
   });
 
   assert.equal(props.Title.title[0].text.content, 'rougeflipper');
-  assert.equal(props['Project Key'].rich_text[0].text.content, 'kafkalm/rougeflipper');
+  assert.equal(props['Project Key'].rich_text[0].text.content, 'MoonSpineStudio/rougeflipper');
   assert.equal(props.Status.select.name, 'Active');
   assert.equal(props.Health, undefined);
-  assert.equal(props['Repository URL'].url, 'https://github.com/kafkalm/rougeflipper');
+  assert.equal(props['Repository URL'].url, 'https://github.com/MoonSpineStudio/rougeflipper');
   assert.equal(props['Last Synced At'].date.start, '2026-02-27T12:00:00.000Z');
 });


### PR DESCRIPTION
## Summary
- replace legacy `kafkalm/...` owner fixtures in repository tests with `MoonSpineStudio/...`
- keep fixture semantics unchanged while aligning migration-facing GitHub URL expectations
- update local `origin` remote to `https://github.com/MoonSpineStudio/spcrop.git` to remove redirect warnings

## Validation
- `node --test scripts/onboard_repo_core.test.mjs`
- `node --test .github/scripts/notion_sync_core.test.mjs .github/scripts/pr_issue_link_guard.test.mjs`
- `npm run typecheck`
- `npm run build`

Resolves #1
