### PR TITLE
feat: add AI image generation with OpenAI and Gemini

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,90 @@
         <button id="exportBtn" type="button">导出 PNG（选中优先） (E)</button>
         <p class="tips">提示：滚轮可上下左右平移画布；中键也可拖动画布。缩放修饰键可在下方设置（默认 Alt/Option(⌥)+滚轮）。画布带像素标尺。框选后可拖动选框，Shift 锁定 1:1。支持一键去除仿 PNG 格子背景，也支持 Ctrl/Cmd+C 复制框选、Ctrl/Cmd+V 粘贴为新图层。按 Backspace 可删除框选内容（无框选时删除选中图层）。在画布中可用 Alt/Option+点击进行多图层点选。</p>
 
+        <h2>AI 生图</h2>
+        <div class="row">
+          <label for="aiProvider">Provider</label>
+          <select id="aiProvider">
+            <option value="openai">OpenAI (GPT)</option>
+            <option value="gemini">NanoBanana (Gemini)</option>
+          </select>
+        </div>
+        <div class="row">
+          <label for="aiMode">模式</label>
+          <select id="aiMode">
+            <option value="text_to_image">文生图</option>
+            <option value="image_to_image">图生图</option>
+          </select>
+        </div>
+        <div class="row">
+          <label for="aiSourceKind">来源</label>
+          <select id="aiSourceKind">
+            <option value="crop">当前框选</option>
+            <option value="active_layer">当前活动图层</option>
+            <option value="gallery_item">素材区选中图</option>
+          </select>
+        </div>
+        <div class="row row-textarea">
+          <label for="aiPrompt">Prompt</label>
+          <textarea id="aiPrompt" rows="4" placeholder="描述你想生成的内容"></textarea>
+        </div>
+        <div class="row row-textarea">
+          <label for="aiNegativePrompt">负向词</label>
+          <textarea id="aiNegativePrompt" rows="2" placeholder="可选：不希望出现的内容"></textarea>
+        </div>
+        <button id="generateAiBtn" type="button">生成 AI 图片</button>
+        <button id="chooseOutputDirBtn" type="button">选择输出目录</button>
+        <div id="outputDirStatus" class="mini-status">输出目录：未设置（将回退为下载）</div>
+        <details id="aiSettingsDetails" class="ai-settings">
+          <summary>AI 设置（密钥/模型/回退）</summary>
+          <div class="row">
+            <label for="openaiApiKey">OpenAI Key</label>
+            <input id="openaiApiKey" type="password" autocomplete="off" placeholder="sk-..." />
+          </div>
+          <div class="row">
+            <label for="openaiBaseUrl">OpenAI Base</label>
+            <input id="openaiBaseUrl" type="text" value="https://api.openai.com" />
+          </div>
+          <div class="row">
+            <label for="openaiModel">OpenAI 模型</label>
+            <input id="openaiModel" type="text" value="gpt-image-1" />
+          </div>
+          <div class="row">
+            <label for="geminiApiKey">Gemini Key</label>
+            <input id="geminiApiKey" type="password" autocomplete="off" placeholder="AIza..." />
+          </div>
+          <div class="row">
+            <label for="geminiBaseUrl">Gemini Base</label>
+            <input id="geminiBaseUrl" type="text" value="https://generativelanguage.googleapis.com" />
+          </div>
+          <div class="row">
+            <label for="geminiModel">Gemini 模型</label>
+            <input id="geminiModel" type="text" value="gemini-2.5-flash-image-preview" />
+          </div>
+          <div class="row">
+            <label for="aiOutputCount">张数</label>
+            <input id="aiOutputCount" type="number" min="1" max="4" value="1" />
+          </div>
+          <div class="row">
+            <label for="enableFallback">回退重试</label>
+            <input id="enableFallback" type="checkbox" checked />
+          </div>
+          <div class="row">
+            <label for="fallbackProvider">回退 Provider</label>
+            <select id="fallbackProvider">
+              <option value="">不启用</option>
+              <option value="openai">OpenAI</option>
+              <option value="gemini">Gemini</option>
+            </select>
+          </div>
+        </details>
+
+        <h2>AI 任务</h2>
+        <div id="aiTaskList" class="ai-task-list"></div>
+
+        <h2>素材候选区</h2>
+        <div id="aiGallery" class="ai-gallery"></div>
+
         <h2>快捷键设置</h2>
         <div class="row">
           <label for="zoomModifierSelect">缩放键</label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "spcrop-gui",
       "devDependencies": {
         "typescript": "^5.9.2",
-        "vite": "^7.1.5"
+        "vite": "^7.1.5",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -452,6 +453,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -802,10 +810,173 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -851,6 +1022,26 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -884,6 +1075,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -902,6 +1103,24 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -997,6 +1216,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1005,6 +1231,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1022,6 +1279,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1111,6 +1378,101 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run"
   },
   "devDependencies": {
     "typescript": "^5.9.2",
-    "vite": "^7.1.5"
+    "vite": "^7.1.5",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/ai/__tests__/fs-output.test.ts
+++ b/src/ai/__tests__/fs-output.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { formatOutputFilename } from "../fs-output";
+
+describe("formatOutputFilename", () => {
+  it("builds stable filename with provider, task id and index", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-04T12:34:56.000Z"));
+
+    const name = formatOutputFilename({
+      provider: "openai",
+      taskId: "task-7",
+      index: 2,
+    });
+
+    expect(name).toBe("20260304-123456-openai-task-7-02.png");
+    vi.useRealTimers();
+  });
+});

--- a/src/ai/__tests__/history-idb.test.ts
+++ b/src/ai/__tests__/history-idb.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import type { TaskRecord } from "../types";
+import { trimTaskHistory } from "../history-idb";
+
+function makeTask(i: number): TaskRecord {
+  return {
+    id: `t-${i}`,
+    provider: i % 2 === 0 ? "openai" : "gemini",
+    mode: "text_to_image",
+    prompt: `prompt-${i}`,
+    status: "succeeded",
+    createdAt: i,
+    outputs: [],
+    outputFiles: [],
+  };
+}
+
+describe("trimTaskHistory", () => {
+  it("keeps newest N tasks by createdAt", () => {
+    const tasks = [makeTask(1), makeTask(5), makeTask(2), makeTask(4), makeTask(3)];
+    const trimmed = trimTaskHistory(tasks, 3);
+
+    expect(trimmed.map((t) => t.id)).toEqual(["t-5", "t-4", "t-3"]);
+  });
+
+  it("returns all tasks when within cap", () => {
+    const tasks = [makeTask(1), makeTask(2)];
+    const trimmed = trimTaskHistory(tasks, 10);
+
+    expect(trimmed.map((t) => t.id)).toEqual(["t-2", "t-1"]);
+  });
+});

--- a/src/ai/__tests__/provider-router.test.ts
+++ b/src/ai/__tests__/provider-router.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import type { GenerateRequest, GeneratedAsset, ProviderAdapter, ProviderId } from "../types";
+import { runWithFallback } from "../provider-router";
+
+function makeRequest(provider: ProviderId): GenerateRequest {
+  return {
+    provider,
+    mode: "text_to_image",
+    prompt: "pixel fox",
+    model: "model-a",
+    outputCount: 1,
+    fallbackProvider: provider === "openai" ? "gemini" : "openai",
+  };
+}
+
+function makeAsset(name: string): GeneratedAsset {
+  return {
+    mimeType: "image/png",
+    blob: new Blob([name], { type: "image/png" }),
+    thumbDataUrl: `data:image/png;base64,${btoa(name)}`,
+    width: 64,
+    height: 64,
+  };
+}
+
+describe("runWithFallback", () => {
+  it("returns primary provider result when primary succeeds", async () => {
+    const calls: ProviderId[] = [];
+    const openai: ProviderAdapter = {
+      generate: async () => {
+        calls.push("openai");
+        return [makeAsset("openai")];
+      },
+    };
+    const gemini: ProviderAdapter = {
+      generate: async () => {
+        calls.push("gemini");
+        return [makeAsset("gemini")];
+      },
+    };
+
+    const result = await runWithFallback(makeRequest("openai"), { openai, gemini });
+
+    expect(result.providerUsed).toBe("openai");
+    expect(result.fallbackFrom).toBeNull();
+    expect(result.assets).toHaveLength(1);
+    expect(calls).toEqual(["openai"]);
+  });
+
+  it("falls back when primary fails and fallback is configured", async () => {
+    const calls: ProviderId[] = [];
+    const openai: ProviderAdapter = {
+      generate: async () => {
+        calls.push("openai");
+        throw new Error("boom");
+      },
+    };
+    const gemini: ProviderAdapter = {
+      generate: async () => {
+        calls.push("gemini");
+        return [makeAsset("gemini")];
+      },
+    };
+
+    const result = await runWithFallback(makeRequest("openai"), { openai, gemini });
+
+    expect(result.providerUsed).toBe("gemini");
+    expect(result.fallbackFrom).toBe("openai");
+    expect(calls).toEqual(["openai", "gemini"]);
+  });
+
+  it("throws primary error when fallback is disabled", async () => {
+    const openai: ProviderAdapter = {
+      generate: async () => {
+        throw new Error("primary failed");
+      },
+    };
+    const gemini: ProviderAdapter = {
+      generate: async () => [makeAsset("gemini")],
+    };
+
+    await expect(
+      runWithFallback(
+        {
+          ...makeRequest("openai"),
+          fallbackProvider: undefined,
+        },
+        { openai, gemini },
+      ),
+    ).rejects.toThrow("primary failed");
+  });
+});

--- a/src/ai/fs-output.ts
+++ b/src/ai/fs-output.ts
@@ -1,0 +1,73 @@
+import type { ProviderId } from "./types";
+
+export interface OutputFilenameInput {
+  provider: ProviderId;
+  taskId: string;
+  index: number;
+  date?: Date;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function sanitizeSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, "-");
+}
+
+export function formatOutputFilename(input: OutputFilenameInput): string {
+  const d = input.date ?? new Date();
+  const yyyy = d.getUTCFullYear();
+  const mm = pad(d.getUTCMonth() + 1);
+  const dd = pad(d.getUTCDate());
+  const hh = pad(d.getUTCHours());
+  const mi = pad(d.getUTCMinutes());
+  const ss = pad(d.getUTCSeconds());
+
+  return `${yyyy}${mm}${dd}-${hh}${mi}${ss}-${input.provider}-${sanitizeSegment(input.taskId)}-${pad(input.index)}.png`;
+}
+
+export function supportsDirectoryPicker(): boolean {
+  return typeof window !== "undefined" && typeof window.showDirectoryPicker === "function";
+}
+
+export async function selectOutputDirectory(): Promise<FileSystemDirectoryHandle> {
+  if (!supportsDirectoryPicker()) {
+    throw new Error("Directory picker is not supported in this browser");
+  }
+  return window.showDirectoryPicker({ mode: "readwrite" });
+}
+
+export async function ensureDirectoryPermission(handle: FileSystemDirectoryHandle): Promise<boolean> {
+  const opts: FileSystemHandlePermissionDescriptor = { mode: "readwrite" };
+  const queried = await handle.queryPermission(opts);
+  if (queried === "granted") {
+    return true;
+  }
+  const requested = await handle.requestPermission(opts);
+  return requested === "granted";
+}
+
+export async function writeBlobToDirectory(
+  handle: FileSystemDirectoryHandle,
+  blob: Blob,
+  filename: string,
+): Promise<void> {
+  const hasPermission = await ensureDirectoryPermission(handle);
+  if (!hasPermission) {
+    throw new Error("No permission to write to selected directory");
+  }
+  const fileHandle = await handle.getFileHandle(filename, { create: true });
+  const writable = await fileHandle.createWritable();
+  await writable.write(blob);
+  await writable.close();
+}
+
+export function downloadBlobFallback(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/ai/gallery-store.ts
+++ b/src/ai/gallery-store.ts
@@ -1,0 +1,27 @@
+import type { GalleryItem, GeneratedAsset, ProviderId } from "./types";
+
+export function createGalleryItemsFromAssets(args: {
+  taskId: string;
+  provider: ProviderId;
+  prompt: string;
+  assets: GeneratedAsset[];
+  createdAt?: number;
+}): GalleryItem[] {
+  const now = args.createdAt ?? Date.now();
+  return args.assets.map((asset, index) => ({
+    id: `${args.taskId}-${index}`,
+    taskId: args.taskId,
+    provider: args.provider,
+    prompt: args.prompt,
+    createdAt: now + index,
+    asset,
+    selectedAsSource: false,
+  }));
+}
+
+export function markSelectedSource(items: GalleryItem[], itemId: string): GalleryItem[] {
+  return items.map((item) => ({
+    ...item,
+    selectedAsSource: item.id === itemId,
+  }));
+}

--- a/src/ai/history-idb.ts
+++ b/src/ai/history-idb.ts
@@ -1,0 +1,138 @@
+import type { GalleryItem, PersistedAiState, TaskRecord } from "./types";
+
+const DB_NAME = "spcrop.ai.history.v1";
+const DB_VERSION = 1;
+const TASK_STORE = "tasks";
+const GALLERY_STORE = "gallery";
+const HANDLE_STORE = "handles";
+const MAX_TASK_HISTORY = 500;
+
+type DbTarget = IDBDatabase | IDBTransaction | IDBObjectStore;
+
+function getStore(target: DbTarget, name: string): IDBObjectStore {
+  if (target instanceof IDBDatabase) {
+    return target.transaction(name, "readwrite").objectStore(name);
+  }
+  if (target instanceof IDBTransaction) {
+    return target.objectStore(name);
+  }
+  return target;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(TASK_STORE)) {
+        db.createObjectStore(TASK_STORE, { keyPath: "id" });
+      }
+      if (!db.objectStoreNames.contains(GALLERY_STORE)) {
+        db.createObjectStore(GALLERY_STORE, { keyPath: "id" });
+      }
+      if (!db.objectStoreNames.contains(HANDLE_STORE)) {
+        db.createObjectStore(HANDLE_STORE);
+      }
+    };
+    request.onerror = () => {
+      reject(request.error ?? new Error("Failed to open IndexedDB"));
+    };
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+  });
+}
+
+function idbRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+}
+
+export function trimTaskHistory(tasks: TaskRecord[], max = MAX_TASK_HISTORY): TaskRecord[] {
+  const normalized = [...tasks].sort((a, b) => b.createdAt - a.createdAt);
+  if (normalized.length <= max) {
+    return normalized;
+  }
+  return normalized.slice(0, max);
+}
+
+export async function saveAiHistory(state: PersistedAiState): Promise<void> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction([TASK_STORE, GALLERY_STORE], "readwrite");
+    const taskStore = getStore(tx, TASK_STORE);
+    const galleryStore = getStore(tx, GALLERY_STORE);
+
+    taskStore.clear();
+    galleryStore.clear();
+
+    for (const task of trimTaskHistory(state.tasks)) {
+      taskStore.put(task);
+    }
+
+    const validTaskIds = new Set(trimTaskHistory(state.tasks).map((t) => t.id));
+    for (const item of state.gallery) {
+      if (validTaskIds.has(item.taskId)) {
+        galleryStore.put(item);
+      }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error("Failed to save AI history"));
+      tx.onabort = () => reject(tx.error ?? new Error("AI history transaction aborted"));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export async function loadAiHistory(): Promise<PersistedAiState> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction([TASK_STORE, GALLERY_STORE], "readonly");
+    const tasks = (await idbRequest(getStore(tx, TASK_STORE).getAll())) as TaskRecord[];
+    const gallery = (await idbRequest(getStore(tx, GALLERY_STORE).getAll())) as GalleryItem[];
+
+    return {
+      tasks: trimTaskHistory(tasks),
+      gallery: gallery
+        .filter((item) => tasks.some((task) => task.id === item.taskId))
+        .sort((a, b) => b.createdAt - a.createdAt),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+const OUTPUT_DIR_KEY = "output-directory";
+
+export async function saveOutputDirectoryHandle(handle: FileSystemDirectoryHandle): Promise<void> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(HANDLE_STORE, "readwrite");
+    getStore(tx, HANDLE_STORE).put(handle, OUTPUT_DIR_KEY);
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error("Failed to save output directory handle"));
+      tx.onabort = () => reject(tx.error ?? new Error("Save handle transaction aborted"));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export async function loadOutputDirectoryHandle(): Promise<FileSystemDirectoryHandle | null> {
+  const db = await openDb();
+  try {
+    const tx = db.transaction(HANDLE_STORE, "readonly");
+    const handle = (await idbRequest(getStore(tx, HANDLE_STORE).get(OUTPUT_DIR_KEY))) as
+      | FileSystemDirectoryHandle
+      | undefined;
+    return handle ?? null;
+  } finally {
+    db.close();
+  }
+}

--- a/src/ai/image-source.ts
+++ b/src/ai/image-source.ts
@@ -1,0 +1,34 @@
+import type { ImageInput, ImageSourceKind } from "./types";
+
+export async function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error("Failed to convert canvas to blob"));
+        return;
+      }
+      resolve(blob);
+    }, "image/png");
+  });
+}
+
+export async function imageBitmapToPngBlob(bitmap: ImageBitmap): Promise<Blob> {
+  const canvas = document.createElement("canvas");
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("2D context is unavailable");
+  }
+  ctx.drawImage(bitmap, 0, 0);
+  return canvasToPngBlob(canvas);
+}
+
+export function buildImageInput(kind: ImageSourceKind, blob: Blob, name?: string): ImageInput {
+  return {
+    kind,
+    blob,
+    mimeType: blob.type || "image/png",
+    name,
+  };
+}

--- a/src/ai/image-utils.ts
+++ b/src/ai/image-utils.ts
@@ -1,0 +1,55 @@
+import type { GeneratedAsset } from "./types";
+
+export async function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject(new Error("Failed to read blob as data URL"));
+        return;
+      }
+      resolve(reader.result);
+    };
+    reader.onerror = () => {
+      reject(reader.error ?? new Error("Failed to read blob"));
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+export async function makeGeneratedAsset(blob: Blob): Promise<GeneratedAsset> {
+  const thumbDataUrl = await blobToDataUrl(blob);
+  let width: number | undefined;
+  let height: number | undefined;
+  try {
+    const bitmap = await createImageBitmap(blob);
+    width = bitmap.width;
+    height = bitmap.height;
+    bitmap.close();
+  } catch {
+    // Ignore decode failures for width/height probing.
+  }
+
+  return {
+    mimeType: blob.type || "image/png",
+    blob,
+    width,
+    height,
+    thumbDataUrl,
+  };
+}
+
+export function dataUrlToBlob(dataUrl: string): Blob {
+  const [header, payload] = dataUrl.split(",");
+  if (!header || !payload) {
+    throw new Error("Invalid data URL");
+  }
+  const mimeMatch = header.match(/data:(.*?);base64/);
+  const mime = mimeMatch ? mimeMatch[1] : "application/octet-stream";
+  const binary = atob(payload);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mime });
+}

--- a/src/ai/provider-router.ts
+++ b/src/ai/provider-router.ts
@@ -1,0 +1,44 @@
+import type { ProviderAdapterMap, RunWithFallbackResult, GenerateRequest, ProviderId } from "./types";
+
+function getAdapter(provider: ProviderId, adapters: ProviderAdapterMap) {
+  if (provider === "openai") {
+    return adapters.openai;
+  }
+  return adapters.gemini;
+}
+
+export async function runWithFallback(
+  request: GenerateRequest,
+  adapters: ProviderAdapterMap,
+  signal?: AbortSignal,
+): Promise<RunWithFallbackResult> {
+  const primaryProvider = request.provider;
+  const primary = getAdapter(primaryProvider, adapters);
+
+  try {
+    const assets = await primary.generate(request, signal);
+    return {
+      assets,
+      providerUsed: primaryProvider,
+      fallbackFrom: null,
+    };
+  } catch (primaryError) {
+    const fallbackProvider = request.fallbackProvider;
+    if (!fallbackProvider || fallbackProvider === primaryProvider) {
+      throw primaryError;
+    }
+
+    const fallback = getAdapter(fallbackProvider, adapters);
+    const fallbackRequest: GenerateRequest = {
+      ...request,
+      provider: fallbackProvider,
+      fallbackProvider: undefined,
+    };
+    const assets = await fallback.generate(fallbackRequest, signal);
+    return {
+      assets,
+      providerUsed: fallbackProvider,
+      fallbackFrom: primaryProvider,
+    };
+  }
+}

--- a/src/ai/providers/gemini.ts
+++ b/src/ai/providers/gemini.ts
@@ -1,0 +1,134 @@
+import { makeGeneratedAsset } from "../image-utils";
+import type { GenerateRequest, ProviderAdapter } from "../types";
+
+export interface GeminiConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+interface GeminiPart {
+  text?: string;
+  inlineData?: {
+    mimeType: string;
+    data: string;
+  };
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/$/, "");
+}
+
+function b64ToBlob(base64: string, mimeType: string): Blob {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mimeType });
+}
+
+async function ensureOk(response: Response): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+  let detail = "";
+  try {
+    const json = (await response.json()) as { error?: { message?: string } };
+    detail = json.error?.message ? `: ${json.error.message}` : "";
+  } catch {
+    // Ignore parsing failure.
+  }
+  throw new Error(`Gemini request failed (${response.status})${detail}`);
+}
+
+function buildPromptText(req: GenerateRequest): string {
+  if (!req.negativePrompt) {
+    return req.prompt;
+  }
+  return `${req.prompt}\n\nAvoid: ${req.negativePrompt}`;
+}
+
+export function createGeminiAdapter(getConfig: () => GeminiConfig): ProviderAdapter {
+  return {
+    async generate(req: GenerateRequest, signal?: AbortSignal) {
+      const config = getConfig();
+      if (!config.apiKey.trim()) {
+        throw new Error("Missing Gemini API key");
+      }
+
+      const baseUrl = normalizeBaseUrl(config.baseUrl || "https://generativelanguage.googleapis.com");
+      const model = req.model;
+      const apiUrl = `${baseUrl}/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(config.apiKey)}`;
+
+      const parts: GeminiPart[] = [
+        {
+          text: buildPromptText(req),
+        },
+      ];
+
+      if (req.mode === "image_to_image") {
+        if (!req.imageSource) {
+          throw new Error("Image source is required for image-to-image mode");
+        }
+        const data = await req.imageSource.blob.arrayBuffer();
+        const bytes = new Uint8Array(data);
+        let binary = "";
+        for (const byte of bytes) {
+          binary += String.fromCharCode(byte);
+        }
+        parts.push({
+          inlineData: {
+            mimeType: req.imageSource.mimeType || "image/png",
+            data: btoa(binary),
+          },
+        });
+      }
+
+      const response = await fetch(apiUrl, {
+        method: "POST",
+        signal,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          contents: [
+            {
+              role: "user",
+              parts,
+            },
+          ],
+          generationConfig: {
+            responseModalities: ["TEXT", "IMAGE"],
+            candidateCount: Math.max(1, req.outputCount),
+          },
+        }),
+      });
+
+      await ensureOk(response);
+
+      const payload = (await response.json()) as {
+        candidates?: Array<{ content?: { parts?: GeminiPart[] } }>;
+      };
+
+      const blobs: Blob[] = [];
+      for (const candidate of payload.candidates ?? []) {
+        for (const part of candidate.content?.parts ?? []) {
+          if (part.inlineData?.data) {
+            blobs.push(b64ToBlob(part.inlineData.data, part.inlineData.mimeType || "image/png"));
+          }
+        }
+      }
+
+      if (blobs.length === 0) {
+        throw new Error("Gemini returned no images");
+      }
+
+      const assets = [];
+      for (const blob of blobs) {
+        // eslint-disable-next-line no-await-in-loop
+        assets.push(await makeGeneratedAsset(blob));
+      }
+      return assets;
+    },
+  };
+}

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -1,0 +1,135 @@
+import { makeGeneratedAsset } from "../image-utils";
+import type { GenerateRequest, ProviderAdapter } from "../types";
+
+export interface OpenAIConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/$/, "");
+}
+
+async function ensureOk(response: Response): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+  let detail = "";
+  try {
+    const json = (await response.json()) as { error?: { message?: string } };
+    detail = json.error?.message ? `: ${json.error.message}` : "";
+  } catch {
+    // Ignore parsing failure.
+  }
+  throw new Error(`OpenAI request failed (${response.status})${detail}`);
+}
+
+function b64ToBlob(base64: string, mimeType: string): Blob {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mimeType });
+}
+
+async function responseDataToAssets(data: Array<{ b64_json?: string; url?: string }>): Promise<Blob[]> {
+  const blobs: Blob[] = [];
+  for (const item of data) {
+    if (item.b64_json) {
+      blobs.push(b64ToBlob(item.b64_json, "image/png"));
+      continue;
+    }
+    if (item.url) {
+      const fetched = await fetch(item.url);
+      if (!fetched.ok) {
+        throw new Error("OpenAI image URL download failed");
+      }
+      blobs.push(await fetched.blob());
+    }
+  }
+  return blobs;
+}
+
+export function createOpenAIAdapter(getConfig: () => OpenAIConfig): ProviderAdapter {
+  return {
+    async generate(req: GenerateRequest, signal?: AbortSignal) {
+      const config = getConfig();
+      if (!config.apiKey.trim()) {
+        throw new Error("Missing OpenAI API key");
+      }
+
+      const headers = {
+        Authorization: `Bearer ${config.apiKey}`,
+      };
+
+      const baseUrl = normalizeBaseUrl(config.baseUrl || "https://api.openai.com");
+
+      if (req.mode === "text_to_image") {
+        const response = await fetch(`${baseUrl}/v1/images/generations`, {
+          method: "POST",
+          signal,
+          headers: {
+            ...headers,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: req.model,
+            prompt: req.negativePrompt
+              ? `${req.prompt}\n\nNegative prompt: ${req.negativePrompt}`
+              : req.prompt,
+            n: Math.max(1, req.outputCount),
+            response_format: "b64_json",
+          }),
+        });
+
+        await ensureOk(response);
+        const payload = (await response.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
+        const blobs = await responseDataToAssets(payload.data ?? []);
+        if (blobs.length === 0) {
+          throw new Error("OpenAI returned no images");
+        }
+        const assets = [];
+        for (const blob of blobs) {
+          // eslint-disable-next-line no-await-in-loop
+          assets.push(await makeGeneratedAsset(blob));
+        }
+        return assets;
+      }
+
+      if (!req.imageSource) {
+        throw new Error("Image source is required for image-to-image mode");
+      }
+
+      const formData = new FormData();
+      formData.append("model", req.model);
+      formData.append(
+        "prompt",
+        req.negativePrompt ? `${req.prompt}\n\nNegative prompt: ${req.negativePrompt}` : req.prompt,
+      );
+      formData.append("n", String(Math.max(1, req.outputCount)));
+      formData.append("response_format", "b64_json");
+      formData.append("image", req.imageSource.blob, req.imageSource.name || "source.png");
+
+      const response = await fetch(`${baseUrl}/v1/images/edits`, {
+        method: "POST",
+        signal,
+        headers,
+        body: formData,
+      });
+
+      await ensureOk(response);
+      const payload = (await response.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
+      const blobs = await responseDataToAssets(payload.data ?? []);
+      if (blobs.length === 0) {
+        throw new Error("OpenAI returned no images");
+      }
+      const assets = [];
+      for (const blob of blobs) {
+        // eslint-disable-next-line no-await-in-loop
+        assets.push(await makeGeneratedAsset(blob));
+      }
+      return assets;
+    },
+  };
+}

--- a/src/ai/task-store.ts
+++ b/src/ai/task-store.ts
@@ -1,0 +1,33 @@
+import type { TaskRecord, GenerateRequest, ProviderId, TaskStatus } from "./types";
+
+export interface TaskPatch {
+  status?: TaskStatus;
+  startedAt?: number;
+  finishedAt?: number;
+  error?: string;
+  fallbackFrom?: ProviderId;
+  outputFiles?: string[];
+}
+
+export function createTaskRecord(request: GenerateRequest): TaskRecord {
+  const now = Date.now();
+  return {
+    id: `task-${now}-${Math.random().toString(36).slice(2, 8)}`,
+    provider: request.provider,
+    mode: request.mode,
+    prompt: request.prompt,
+    status: "pending",
+    createdAt: now,
+    outputs: [],
+    outputFiles: [],
+    imageSourceKind: request.imageSource?.kind,
+  };
+}
+
+export function patchTaskRecord(task: TaskRecord, patch: TaskPatch): TaskRecord {
+  return {
+    ...task,
+    ...patch,
+    outputFiles: patch.outputFiles ?? task.outputFiles,
+  };
+}

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,0 +1,92 @@
+export type ProviderId = "openai" | "gemini";
+
+export type GenerationMode = "text_to_image" | "image_to_image";
+
+export type ImageSourceKind = "crop" | "active_layer" | "gallery_item";
+
+export interface ImageInput {
+  kind: ImageSourceKind;
+  blob: Blob;
+  mimeType: string;
+  name?: string;
+}
+
+export interface GenerateRequest {
+  provider: ProviderId;
+  mode: GenerationMode;
+  prompt: string;
+  negativePrompt?: string;
+  imageSource?: ImageInput;
+  model: string;
+  outputCount: number;
+  fallbackProvider?: ProviderId;
+}
+
+export interface GeneratedAsset {
+  mimeType: string;
+  blob: Blob;
+  width?: number;
+  height?: number;
+  thumbDataUrl: string;
+}
+
+export type TaskStatus = "pending" | "running" | "succeeded" | "failed" | "canceled";
+
+export interface TaskRecord {
+  id: string;
+  provider: ProviderId;
+  mode: GenerationMode;
+  prompt: string;
+  status: TaskStatus;
+  createdAt: number;
+  startedAt?: number;
+  finishedAt?: number;
+  error?: string;
+  fallbackFrom?: ProviderId;
+  outputs: GeneratedAsset[];
+  outputFiles: string[];
+  imageSourceKind?: ImageSourceKind;
+}
+
+export interface ProviderAdapter {
+  generate(req: GenerateRequest, signal?: AbortSignal): Promise<GeneratedAsset[]>;
+}
+
+export interface ProviderAdapterMap {
+  openai: ProviderAdapter;
+  gemini: ProviderAdapter;
+}
+
+export interface RunWithFallbackResult {
+  assets: GeneratedAsset[];
+  providerUsed: ProviderId;
+  fallbackFrom: ProviderId | null;
+}
+
+export interface AiSettings {
+  openaiApiKey: string;
+  openaiBaseUrl: string;
+  openaiModel: string;
+  geminiApiKey: string;
+  geminiBaseUrl: string;
+  geminiModel: string;
+  enableFallback: boolean;
+  fallbackProvider: "" | ProviderId;
+  outputCount: number;
+}
+
+export interface GalleryItem {
+  id: string;
+  taskId: string;
+  provider: ProviderId;
+  createdAt: number;
+  prompt: string;
+  asset: GeneratedAsset;
+  selectedAsSource: boolean;
+  outputFile?: string;
+}
+
+export interface PersistedAiState {
+  tasks: TaskRecord[];
+  gallery: GalleryItem[];
+}

--- a/src/filesystem-access.d.ts
+++ b/src/filesystem-access.d.ts
@@ -1,0 +1,42 @@
+type FileSystemPermissionMode = "read" | "readwrite";
+
+type FileSystemPermissionState = "granted" | "denied" | "prompt";
+
+interface FileSystemHandlePermissionDescriptor {
+  mode?: FileSystemPermissionMode;
+}
+
+interface FileSystemHandle {
+  kind: "file" | "directory";
+  name: string;
+  queryPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<FileSystemPermissionState>;
+  requestPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<FileSystemPermissionState>;
+}
+
+interface FileSystemWritableFileStream extends WritableStream {
+  write(data: BufferSource | Blob | string): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface FileSystemFileHandle extends FileSystemHandle {
+  createWritable(options?: { keepExistingData?: boolean }): Promise<FileSystemWritableFileStream>;
+  getFile(): Promise<File>;
+}
+
+interface FileSystemGetFileOptions {
+  create?: boolean;
+}
+
+interface FileSystemDirectoryHandle extends FileSystemHandle {
+  getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<FileSystemFileHandle>;
+}
+
+interface DirectoryPickerOptions {
+  id?: string;
+  mode?: FileSystemPermissionMode;
+  startIn?: string | FileSystemHandle;
+}
+
+interface Window {
+  showDirectoryPicker(options?: DirectoryPickerOptions): Promise<FileSystemDirectoryHandle>;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,36 @@
 import "./styles.css";
+import { createGalleryItemsFromAssets, markSelectedSource } from "./ai/gallery-store";
+import {
+  loadAiHistory,
+  loadOutputDirectoryHandle,
+  saveAiHistory,
+  saveOutputDirectoryHandle,
+} from "./ai/history-idb";
+import { dataUrlToBlob } from "./ai/image-utils";
+import { buildImageInput, canvasToPngBlob, imageBitmapToPngBlob } from "./ai/image-source";
+import {
+  downloadBlobFallback,
+  ensureDirectoryPermission,
+  formatOutputFilename,
+  selectOutputDirectory,
+  supportsDirectoryPicker,
+  writeBlobToDirectory,
+} from "./ai/fs-output";
+import { runWithFallback } from "./ai/provider-router";
+import { createTaskRecord, patchTaskRecord } from "./ai/task-store";
+import { createGeminiAdapter } from "./ai/providers/gemini";
+import { createOpenAIAdapter } from "./ai/providers/openai";
+import type {
+  AiSettings,
+  GalleryItem,
+  GenerateRequest,
+  GenerationMode,
+  ImageInput,
+  ImageSourceKind,
+  PersistedAiState,
+  ProviderId,
+  TaskRecord,
+} from "./ai/types";
 
 type LayerImage = ImageBitmap | HTMLCanvasElement;
 
@@ -83,6 +115,30 @@ type ZoomModifier = "Alt" | "Ctrl" | "Meta" | "Shift" | "None";
 
 const SHORTCUT_STORAGE_KEY = "spcrop.shortcuts.v1";
 const ZOOM_MODIFIER_STORAGE_KEY = "spcrop.zoomModifier.v1";
+const AI_SETTINGS_STORAGE_KEY = "spcrop.ai.settings.v1";
+
+const DEFAULT_AI_SETTINGS: AiSettings = {
+  openaiApiKey: "",
+  openaiBaseUrl: "https://api.openai.com",
+  openaiModel: "gpt-image-1",
+  geminiApiKey: "",
+  geminiBaseUrl: "https://generativelanguage.googleapis.com",
+  geminiModel: "gemini-2.5-flash-image-preview",
+  enableFallback: true,
+  fallbackProvider: "",
+  outputCount: 1,
+};
+
+interface AiRuntimeState {
+  settings: AiSettings;
+  tasks: TaskRecord[];
+  gallery: GalleryItem[];
+  selectedSourceKind: ImageSourceKind;
+  outputDirHandle: FileSystemDirectoryHandle | null;
+  outputDirReady: boolean;
+  taskAbortControllers: Map<string, AbortController>;
+  persistingHistory: Promise<void> | null;
+}
 
 const SHORTCUT_DEFS: ShortcutDef[] = [
   { action: "toggleCropMode", label: "开始/结束框选", defaultKey: "C" },
@@ -175,6 +231,25 @@ const zoomModifierSelect = mustGet<HTMLSelectElement>("zoomModifierSelect");
 const layerList = mustGet<HTMLUListElement>("layerList");
 const shortcutList = mustGet<HTMLDivElement>("shortcutList");
 const resetShortcutBtn = mustGet<HTMLButtonElement>("resetShortcutBtn");
+const aiProviderSelect = mustGet<HTMLSelectElement>("aiProvider");
+const aiModeSelect = mustGet<HTMLSelectElement>("aiMode");
+const aiSourceKindSelect = mustGet<HTMLSelectElement>("aiSourceKind");
+const aiPromptInput = mustGet<HTMLTextAreaElement>("aiPrompt");
+const aiNegativePromptInput = mustGet<HTMLTextAreaElement>("aiNegativePrompt");
+const generateAiBtn = mustGet<HTMLButtonElement>("generateAiBtn");
+const chooseOutputDirBtn = mustGet<HTMLButtonElement>("chooseOutputDirBtn");
+const outputDirStatus = mustGet<HTMLDivElement>("outputDirStatus");
+const aiTaskList = mustGet<HTMLDivElement>("aiTaskList");
+const aiGallery = mustGet<HTMLDivElement>("aiGallery");
+const openaiApiKeyInput = mustGet<HTMLInputElement>("openaiApiKey");
+const openaiBaseUrlInput = mustGet<HTMLInputElement>("openaiBaseUrl");
+const openaiModelInput = mustGet<HTMLInputElement>("openaiModel");
+const geminiApiKeyInput = mustGet<HTMLInputElement>("geminiApiKey");
+const geminiBaseUrlInput = mustGet<HTMLInputElement>("geminiBaseUrl");
+const geminiModelInput = mustGet<HTMLInputElement>("geminiModel");
+const aiOutputCountInput = mustGet<HTMLInputElement>("aiOutputCount");
+const enableFallbackInput = mustGet<HTMLInputElement>("enableFallback");
+const fallbackProviderSelect = mustGet<HTMLSelectElement>("fallbackProvider");
 
 function defaultShortcutMap(): Record<ShortcutAction, string> {
   const map = {} as Record<ShortcutAction, string>;
@@ -210,6 +285,17 @@ const state: AppState = {
   dragStartPointer: null,
   clipboardImage: null,
   clipboardPasteCursor: null,
+};
+
+const aiState: AiRuntimeState = {
+  settings: { ...DEFAULT_AI_SETTINGS },
+  tasks: [],
+  gallery: [],
+  selectedSourceKind: "crop",
+  outputDirHandle: null,
+  outputDirReady: false,
+  taskAbortControllers: new Map<string, AbortController>(),
+  persistingHistory: null,
 };
 
 function setStatus(text: string): void {
@@ -1032,6 +1118,12 @@ async function addLayerFromFile(file: File): Promise<void> {
   setStatus(`已导入图层: ${layer.name}`);
 }
 
+async function addLayerFromBlob(blob: Blob, baseName: string): Promise<void> {
+  const ext = blob.type.includes("jpeg") ? "jpg" : "png";
+  const file = new File([blob], `${baseName}.${ext}`, { type: blob.type || "image/png" });
+  await addLayerFromFile(file);
+}
+
 async function handleFiles(files: File[]): Promise<void> {
   const imageFiles = files.filter((f) => f.type.startsWith("image/"));
   if (imageFiles.length === 0) {
@@ -1438,6 +1530,508 @@ function downloadBlob(blob: Blob, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
+function isProviderId(value: string): value is ProviderId {
+  return value === "openai" || value === "gemini";
+}
+
+function isGenerationMode(value: string): value is GenerationMode {
+  return value === "text_to_image" || value === "image_to_image";
+}
+
+function isImageSourceKind(value: string): value is ImageSourceKind {
+  return value === "crop" || value === "active_layer" || value === "gallery_item";
+}
+
+function loadAiSettings(): void {
+  try {
+    const raw = window.localStorage.getItem(AI_SETTINGS_STORAGE_KEY);
+    if (!raw) {
+      aiState.settings = { ...DEFAULT_AI_SETTINGS };
+      return;
+    }
+    const parsed = JSON.parse(raw) as Partial<AiSettings>;
+    aiState.settings = {
+      ...DEFAULT_AI_SETTINGS,
+      ...parsed,
+      outputCount: clamp(Number(parsed.outputCount ?? DEFAULT_AI_SETTINGS.outputCount), 1, 4),
+      fallbackProvider: parsed.fallbackProvider === "openai" || parsed.fallbackProvider === "gemini"
+        ? parsed.fallbackProvider
+        : "",
+    };
+  } catch {
+    aiState.settings = { ...DEFAULT_AI_SETTINGS };
+  }
+}
+
+function saveAiSettings(): void {
+  try {
+    window.localStorage.setItem(AI_SETTINGS_STORAGE_KEY, JSON.stringify(aiState.settings));
+  } catch {
+    // Ignore localStorage failures.
+  }
+}
+
+function syncAiSettingsToUI(): void {
+  openaiApiKeyInput.value = aiState.settings.openaiApiKey;
+  openaiBaseUrlInput.value = aiState.settings.openaiBaseUrl;
+  openaiModelInput.value = aiState.settings.openaiModel;
+  geminiApiKeyInput.value = aiState.settings.geminiApiKey;
+  geminiBaseUrlInput.value = aiState.settings.geminiBaseUrl;
+  geminiModelInput.value = aiState.settings.geminiModel;
+  aiOutputCountInput.value = String(aiState.settings.outputCount);
+  enableFallbackInput.checked = aiState.settings.enableFallback;
+  fallbackProviderSelect.value = aiState.settings.fallbackProvider;
+}
+
+function syncAiSettingsFromUI(): void {
+  aiState.settings.openaiApiKey = openaiApiKeyInput.value.trim();
+  aiState.settings.openaiBaseUrl = openaiBaseUrlInput.value.trim() || DEFAULT_AI_SETTINGS.openaiBaseUrl;
+  aiState.settings.openaiModel = openaiModelInput.value.trim() || DEFAULT_AI_SETTINGS.openaiModel;
+  aiState.settings.geminiApiKey = geminiApiKeyInput.value.trim();
+  aiState.settings.geminiBaseUrl = geminiBaseUrlInput.value.trim() || DEFAULT_AI_SETTINGS.geminiBaseUrl;
+  aiState.settings.geminiModel = geminiModelInput.value.trim() || DEFAULT_AI_SETTINGS.geminiModel;
+  aiState.settings.outputCount = clamp(Number(aiOutputCountInput.value) || 1, 1, 4);
+  aiState.settings.enableFallback = enableFallbackInput.checked;
+  const fallbackValue = fallbackProviderSelect.value;
+  aiState.settings.fallbackProvider = isProviderId(fallbackValue) ? fallbackValue : "";
+  saveAiSettings();
+}
+
+function getActiveProvider(): ProviderId {
+  const raw = aiProviderSelect.value;
+  return isProviderId(raw) ? raw : "openai";
+}
+
+function getActiveMode(): GenerationMode {
+  const raw = aiModeSelect.value;
+  return isGenerationMode(raw) ? raw : "text_to_image";
+}
+
+function getSelectedSourceKind(): ImageSourceKind {
+  const raw = aiSourceKindSelect.value;
+  return isImageSourceKind(raw) ? raw : "crop";
+}
+
+function makeProviderRequest(req: GenerateRequest): GenerateRequest {
+  const fallback = aiState.settings.enableFallback
+    ? (aiState.settings.fallbackProvider || (req.provider === "openai" ? "gemini" : "openai"))
+    : undefined;
+  const fallbackProvider = fallback && fallback !== req.provider ? fallback : undefined;
+  return {
+    ...req,
+    fallbackProvider,
+  };
+}
+
+const openaiAdapter = createOpenAIAdapter(() => ({
+  apiKey: aiState.settings.openaiApiKey,
+  baseUrl: aiState.settings.openaiBaseUrl,
+}));
+
+const geminiAdapter = createGeminiAdapter(() => ({
+  apiKey: aiState.settings.geminiApiKey,
+  baseUrl: aiState.settings.geminiBaseUrl,
+}));
+
+function refreshOutputDirStatus(): void {
+  if (!supportsDirectoryPicker()) {
+    outputDirStatus.textContent = "输出目录：浏览器不支持目录授权，将回退为下载";
+    return;
+  }
+  if (!aiState.outputDirHandle) {
+    outputDirStatus.textContent = "输出目录：未设置（将回退为下载）";
+    return;
+  }
+  outputDirStatus.textContent = aiState.outputDirReady
+    ? "输出目录：已授权，可直接写入"
+    : "输出目录：句柄已记住，但当前未授权（将回退下载）";
+}
+
+function taskErrorToMessage(error: unknown): string {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return "任务已取消";
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "任务失败";
+}
+
+function renderAiTaskList(): void {
+  aiTaskList.innerHTML = "";
+  const tasks = [...aiState.tasks].sort((a, b) => b.createdAt - a.createdAt);
+  for (const task of tasks) {
+    const item = document.createElement("div");
+    item.className = "ai-task-item";
+
+    const title = document.createElement("div");
+    title.className = "ai-task-title";
+    title.textContent = `[${task.provider}] ${task.status}`;
+
+    const meta = document.createElement("div");
+    meta.className = "ai-task-meta";
+    meta.textContent = `${new Date(task.createdAt).toLocaleString()} · ${task.mode} · ${task.prompt}`;
+    item.appendChild(title);
+    item.appendChild(meta);
+
+    if (task.error) {
+      const err = document.createElement("div");
+      err.className = "ai-task-meta";
+      err.textContent = `错误：${task.error}`;
+      item.appendChild(err);
+    }
+
+    const actions = document.createElement("div");
+    actions.className = "ai-task-actions";
+
+    if (task.status === "running") {
+      const cancelBtn = document.createElement("button");
+      cancelBtn.type = "button";
+      cancelBtn.textContent = "取消";
+      cancelBtn.addEventListener("click", () => {
+        const controller = aiState.taskAbortControllers.get(task.id);
+        if (controller) {
+          controller.abort();
+        }
+      });
+      actions.appendChild(cancelBtn);
+    }
+
+    if (task.status === "failed" || task.status === "canceled") {
+      const retryBtn = document.createElement("button");
+      retryBtn.type = "button";
+      retryBtn.textContent = "重试（当前设置）";
+      retryBtn.addEventListener("click", () => {
+        aiPromptInput.value = task.prompt;
+        aiModeSelect.value = task.mode;
+        aiProviderSelect.value = task.provider;
+        generateAiBtn.click();
+      });
+      actions.appendChild(retryBtn);
+    }
+
+    if (actions.childElementCount > 0) {
+      item.appendChild(actions);
+    }
+    aiTaskList.appendChild(item);
+  }
+}
+
+function ensureAssetBlob(item: GalleryItem): Blob {
+  if (item.asset.blob instanceof Blob) {
+    return item.asset.blob;
+  }
+  return dataUrlToBlob(item.asset.thumbDataUrl);
+}
+
+async function persistAiHistory(): Promise<void> {
+  const snapshot: PersistedAiState = {
+    tasks: aiState.tasks,
+    gallery: aiState.gallery,
+  };
+  const run = async () => {
+    try {
+      await saveAiHistory(snapshot);
+    } catch {
+      // Ignore persistence errors.
+    }
+  };
+  aiState.persistingHistory = (aiState.persistingHistory ?? Promise.resolve()).then(run, run);
+  await aiState.persistingHistory;
+}
+
+function renderAiGallery(): void {
+  aiGallery.innerHTML = "";
+  const items = [...aiState.gallery].sort((a, b) => b.createdAt - a.createdAt);
+  for (const item of items) {
+    const card = document.createElement("div");
+    card.className = "ai-gallery-item";
+    if (item.selectedAsSource) {
+      card.classList.add("selected-source");
+    }
+
+    const img = document.createElement("img");
+    img.className = "ai-gallery-thumb";
+    img.src = item.asset.thumbDataUrl;
+    img.alt = item.prompt.slice(0, 60);
+
+    const meta = document.createElement("div");
+    meta.className = "ai-gallery-meta";
+    meta.textContent = `${item.provider} · ${new Date(item.createdAt).toLocaleTimeString()}`;
+
+    const actions = document.createElement("div");
+    actions.className = "ai-gallery-actions";
+
+    const addLayerBtn = document.createElement("button");
+    addLayerBtn.type = "button";
+    addLayerBtn.textContent = "加入图层";
+    addLayerBtn.addEventListener("click", async () => {
+      const blob = ensureAssetBlob(item);
+      await addLayerFromBlob(blob, `ai-${item.provider}-${item.id}`);
+      setStatus("已将候选图加入图层");
+    });
+
+    const selectSourceBtn = document.createElement("button");
+    selectSourceBtn.type = "button";
+    selectSourceBtn.textContent = "设为图生图来源";
+    selectSourceBtn.addEventListener("click", () => {
+      aiState.gallery = markSelectedSource(aiState.gallery, item.id);
+      aiSourceKindSelect.value = "gallery_item";
+      aiState.selectedSourceKind = "gallery_item";
+      renderAiGallery();
+      persistAiHistory();
+      setStatus("已设置素材来源：候选区选中图");
+    });
+
+    const saveBtn = document.createElement("button");
+    saveBtn.type = "button";
+    saveBtn.textContent = "保存到输出目录";
+    saveBtn.addEventListener("click", async () => {
+      const blob = ensureAssetBlob(item);
+      const index = Math.max(1, Number(item.id.split("-").pop() ?? "1") + 1);
+      const filename = formatOutputFilename({
+        provider: item.provider,
+        taskId: item.taskId,
+        index,
+      });
+      if (aiState.outputDirHandle && aiState.outputDirReady) {
+        try {
+          await writeBlobToDirectory(aiState.outputDirHandle, blob, filename);
+          setStatus(`已保存：${filename}`);
+          return;
+        } catch {
+          aiState.outputDirReady = false;
+          refreshOutputDirStatus();
+        }
+      }
+      downloadBlobFallback(blob, filename);
+      setStatus(`目录不可写，已下载：${filename}`);
+    });
+
+    const downloadBtn = document.createElement("button");
+    downloadBtn.type = "button";
+    downloadBtn.textContent = "下载";
+    downloadBtn.addEventListener("click", () => {
+      const blob = ensureAssetBlob(item);
+      const index = Math.max(1, Number(item.id.split("-").pop() ?? "1") + 1);
+      const filename = formatOutputFilename({
+        provider: item.provider,
+        taskId: item.taskId,
+        index,
+      });
+      downloadBlobFallback(blob, filename);
+      setStatus(`已下载：${filename}`);
+    });
+
+    actions.appendChild(addLayerBtn);
+    actions.appendChild(selectSourceBtn);
+    actions.appendChild(saveBtn);
+    actions.appendChild(downloadBtn);
+    card.appendChild(img);
+    card.appendChild(meta);
+    card.appendChild(actions);
+    aiGallery.appendChild(card);
+  }
+}
+
+async function resolveImageSource(kind: ImageSourceKind): Promise<ImageInput> {
+  if (kind === "crop") {
+    const slice = getActiveCropSlice();
+    if (!slice) {
+      throw new Error("当前没有可用框选区域");
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = slice.sw;
+    canvas.height = slice.sh;
+    const cctx = canvas.getContext("2d");
+    if (!cctx) {
+      throw new Error("2D 上下文不可用");
+    }
+    cctx.drawImage(slice.layer.image, slice.sx, slice.sy, slice.sw, slice.sh, 0, 0, slice.sw, slice.sh);
+    const blob = await canvasToPngBlob(canvas);
+    return buildImageInput("crop", blob, "crop-source.png");
+  }
+
+  if (kind === "active_layer") {
+    const active = state.activeLayerId !== null ? getLayerById(state.activeLayerId) : null;
+    if (!active) {
+      throw new Error("请先选中活动图层");
+    }
+    const blob = active.image instanceof HTMLCanvasElement
+      ? await canvasToPngBlob(active.image)
+      : await imageBitmapToPngBlob(active.image);
+    return buildImageInput("active_layer", blob, "active-layer.png");
+  }
+
+  const selected = aiState.gallery.find((item) => item.selectedAsSource);
+  if (!selected) {
+    throw new Error("请先在素材候选区选择一张来源图");
+  }
+  const blob = ensureAssetBlob(selected);
+  return buildImageInput("gallery_item", blob, "gallery-source.png");
+}
+
+async function writeOutputByPolicy(blob: Blob, provider: ProviderId, taskId: string, index: number): Promise<string> {
+  const filename = formatOutputFilename({
+    provider,
+    taskId,
+    index,
+  });
+  if (aiState.outputDirHandle && aiState.outputDirReady) {
+    try {
+      await writeBlobToDirectory(aiState.outputDirHandle, blob, filename);
+      return filename;
+    } catch {
+      aiState.outputDirReady = false;
+      refreshOutputDirStatus();
+    }
+  }
+  downloadBlobFallback(blob, filename);
+  return `download:${filename}`;
+}
+
+function upsertTask(task: TaskRecord): void {
+  const index = aiState.tasks.findIndex((x) => x.id === task.id);
+  if (index === -1) {
+    aiState.tasks.push(task);
+    return;
+  }
+  aiState.tasks[index] = task;
+}
+
+async function createGenerateRequestFromUI(): Promise<GenerateRequest> {
+  syncAiSettingsFromUI();
+  const provider = getActiveProvider();
+  const mode = getActiveMode();
+  const prompt = aiPromptInput.value.trim();
+  const negativePrompt = aiNegativePromptInput.value.trim();
+  const sourceKind = getSelectedSourceKind();
+  aiState.selectedSourceKind = sourceKind;
+
+  if (!prompt) {
+    throw new Error("Prompt 不能为空");
+  }
+
+  let imageSource: ImageInput | undefined;
+  if (mode === "image_to_image") {
+    imageSource = await resolveImageSource(sourceKind);
+  }
+
+  const model = provider === "openai" ? aiState.settings.openaiModel : aiState.settings.geminiModel;
+  const request = makeProviderRequest({
+    provider,
+    mode,
+    prompt,
+    negativePrompt: negativePrompt || undefined,
+    imageSource,
+    model,
+    outputCount: aiState.settings.outputCount,
+  });
+  return request;
+}
+
+async function runGenerateTask(request: GenerateRequest): Promise<void> {
+  const baseTask = createTaskRecord(request);
+  upsertTask(baseTask);
+  renderAiTaskList();
+  await persistAiHistory();
+
+  const runningTask = patchTaskRecord(baseTask, {
+    status: "running",
+    startedAt: Date.now(),
+    error: undefined,
+  });
+  upsertTask(runningTask);
+  renderAiTaskList();
+
+  const controller = new AbortController();
+  aiState.taskAbortControllers.set(baseTask.id, controller);
+
+  try {
+    const result = await runWithFallback(request, { openai: openaiAdapter, gemini: geminiAdapter }, controller.signal);
+    const outputFiles: string[] = [];
+    for (let i = 0; i < result.assets.length; i++) {
+      const asset = result.assets[i];
+      // eslint-disable-next-line no-await-in-loop
+      const file = await writeOutputByPolicy(asset.blob, result.providerUsed, baseTask.id, i + 1);
+      outputFiles.push(file);
+    }
+
+    const succeeded = patchTaskRecord(runningTask, {
+      status: "succeeded",
+      finishedAt: Date.now(),
+      fallbackFrom: result.fallbackFrom ?? undefined,
+      outputFiles,
+    });
+    succeeded.provider = result.providerUsed;
+    succeeded.outputs = result.assets;
+    upsertTask(succeeded);
+
+    const galleryItems = createGalleryItemsFromAssets({
+      taskId: baseTask.id,
+      provider: result.providerUsed,
+      prompt: request.prompt,
+      assets: result.assets,
+    });
+    aiState.gallery = [...galleryItems, ...aiState.gallery].slice(0, 500);
+
+    setStatus(`AI 生成完成：${result.assets.length} 张 (${result.providerUsed})`);
+  } catch (error) {
+    const message = taskErrorToMessage(error);
+    const failed = patchTaskRecord(runningTask, {
+      status: message === "任务已取消" ? "canceled" : "failed",
+      error: message,
+      finishedAt: Date.now(),
+    });
+    upsertTask(failed);
+    setStatus(`AI 任务失败：${message}`);
+  } finally {
+    aiState.taskAbortControllers.delete(baseTask.id);
+    renderAiTaskList();
+    renderAiGallery();
+    await persistAiHistory();
+  }
+}
+
+async function restoreAiState(): Promise<void> {
+  loadAiSettings();
+  syncAiSettingsToUI();
+  aiState.selectedSourceKind = getSelectedSourceKind();
+
+  try {
+    const history = await loadAiHistory();
+    aiState.tasks = history.tasks;
+    aiState.gallery = history.gallery.map((item) => {
+      const blob = item.asset.blob instanceof Blob ? item.asset.blob : dataUrlToBlob(item.asset.thumbDataUrl);
+      return {
+        ...item,
+        asset: {
+          ...item.asset,
+          blob,
+        },
+      };
+    });
+  } catch {
+    aiState.tasks = [];
+    aiState.gallery = [];
+  }
+
+  try {
+    const handle = await loadOutputDirectoryHandle();
+    if (handle) {
+      aiState.outputDirHandle = handle;
+      aiState.outputDirReady = await ensureDirectoryPermission(handle);
+    }
+  } catch {
+    aiState.outputDirHandle = null;
+    aiState.outputDirReady = false;
+  }
+
+  refreshOutputDirStatus();
+  renderAiTaskList();
+  renderAiGallery();
+}
+
 window.addEventListener("resize", resizeCanvas);
 resizeCanvas();
 
@@ -1675,6 +2269,63 @@ zoomModifierSelect.addEventListener("change", () => {
   state.zoomModifier = value;
   saveZoomModifier();
   setStatus(`已更新缩放修饰键：${zoomModifierLabel(state.zoomModifier)} + 滚轮`);
+});
+
+aiModeSelect.addEventListener("change", () => {
+  const mode = getActiveMode();
+  const imageMode = mode === "image_to_image";
+  aiSourceKindSelect.disabled = !imageMode;
+  setStatus(imageMode ? "AI 模式：图生图（需要来源图）" : "AI 模式：文生图");
+});
+
+aiSourceKindSelect.addEventListener("change", () => {
+  aiState.selectedSourceKind = getSelectedSourceKind();
+});
+
+[
+  openaiApiKeyInput,
+  openaiBaseUrlInput,
+  openaiModelInput,
+  geminiApiKeyInput,
+  geminiBaseUrlInput,
+  geminiModelInput,
+  aiOutputCountInput,
+  enableFallbackInput,
+  fallbackProviderSelect,
+].forEach((el) => {
+  el.addEventListener("change", () => {
+    syncAiSettingsFromUI();
+  });
+});
+
+chooseOutputDirBtn.addEventListener("click", async () => {
+  if (!supportsDirectoryPicker()) {
+    setStatus("当前浏览器不支持目录授权写入，将继续使用下载回退");
+    refreshOutputDirStatus();
+    return;
+  }
+  try {
+    const handle = await selectOutputDirectory();
+    const granted = await ensureDirectoryPermission(handle);
+    aiState.outputDirHandle = handle;
+    aiState.outputDirReady = granted;
+    await saveOutputDirectoryHandle(handle);
+    refreshOutputDirStatus();
+    setStatus(granted ? "输出目录已设置并授权" : "已记住目录句柄，但未获取写入权限");
+  } catch (error) {
+    const message = taskErrorToMessage(error);
+    setStatus(`设置输出目录失败：${message}`);
+  }
+});
+
+generateAiBtn.addEventListener("click", async () => {
+  try {
+    const request = await createGenerateRequestFromUI();
+    await runGenerateTask(request);
+  } catch (error) {
+    const message = taskErrorToMessage(error);
+    setStatus(`无法开始 AI 任务：${message}`);
+  }
 });
 
 stage.addEventListener("mousedown", (event: MouseEvent) => {
@@ -2107,3 +2758,11 @@ refreshActionButtonLabels();
 setStatus(`拖入图片开始编辑。滚轮平移，${zoomModifierLabel(state.zoomModifier)}+滚轮缩放；可在右侧快捷键设置中自定义按键。`);
 refreshLayerList();
 render();
+
+restoreAiState()
+  .then(() => {
+    aiModeSelect.dispatchEvent(new Event("change"));
+  })
+  .catch(() => {
+    refreshOutputDirStatus();
+  });

--- a/src/styles.css
+++ b/src/styles.css
@@ -164,6 +164,22 @@ input {
   padding: 6px 8px;
 }
 
+input[type="checkbox"] {
+  width: auto;
+  justify-self: start;
+}
+
+textarea {
+  width: 100%;
+  background: var(--panel-2);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px 8px;
+  resize: vertical;
+  min-height: 48px;
+}
+
 select {
   width: 100%;
   background: var(--panel-2);
@@ -257,6 +273,120 @@ button:hover {
   margin: 0;
   padding: 5px 8px;
   font-size: 12px;
+}
+
+.row-textarea {
+  grid-template-columns: 1fr;
+}
+
+.row-textarea label {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.mini-status {
+  margin-top: 4px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.35;
+}
+
+.ai-settings {
+  margin: 8px 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.ai-settings summary {
+  cursor: pointer;
+  font-size: 12px;
+  color: #cdd9ef;
+  margin-bottom: 8px;
+}
+
+.ai-task-list {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.ai-task-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.ai-task-title {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.ai-task-meta {
+  font-size: 11px;
+  color: var(--muted);
+  line-height: 1.35;
+}
+
+.ai-task-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.ai-task-actions button {
+  width: auto;
+  margin: 0;
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
+.ai-gallery {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.ai-gallery-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.ai-gallery-item.selected-source {
+  border-color: #ffb703;
+  box-shadow: 0 0 0 1px rgba(255, 183, 3, 0.3) inset;
+}
+
+.ai-gallery-thumb {
+  width: 100%;
+  border-radius: 6px;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.ai-gallery-meta {
+  font-size: 11px;
+  color: var(--muted);
+  line-height: 1.3;
+  margin-bottom: 6px;
+}
+
+.ai-gallery-actions {
+  display: grid;
+  gap: 4px;
+}
+
+.ai-gallery-actions button {
+  margin: 0;
+  font-size: 11px;
+  padding: 5px 6px;
 }
 
 .shortcut-key.capturing {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "skipLibCheck": true,
     "types": ["vite/client"]
   },
-  "include": ["src/**/*.ts", "vite.config.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- add AI generation panel in UI (provider/mode/source/prompt/settings/task list/gallery)
- add OpenAI and Gemini adapters for text-to-image and image-to-image
- add provider fallback routing, unlimited concurrent task runtime, and task cancellation
- persist AI task history + gallery thumbnails in IndexedDB across sessions
- support directory-authorized output writing with browser-download fallback
- integrate generated assets into layer workflow (add to layer, gallery as image source)
- add unit tests for fallback routing, filename formatting, and history trimming

## Validation
- npm test
- npm run typecheck
- npm run build

Resolves #5
