### PR TITLE
feat: separate layer controls and AI tools into left/right panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,24 +7,7 @@
   </head>
   <body>
     <div class="app">
-      <section class="workspace">
-        <div class="toolbar">
-          <button id="cropModeBtn" type="button">开始框选 (C)</button>
-          <button id="clearCropBtn" type="button">清除框选 (X/Esc)</button>
-          <span id="statusText">拖入图片开始编辑</span>
-        </div>
-        <div class="canvas-shell">
-          <div class="ruler-corner"></div>
-          <canvas id="rulerTop" class="ruler-top"></canvas>
-          <canvas id="rulerLeft" class="ruler-left"></canvas>
-          <div class="canvas-wrap" id="dropZone">
-            <canvas id="stage"></canvas>
-            <div class="drop-hint" id="dropHint">拖入 PNG/JPG 图片到这里</div>
-          </div>
-        </div>
-      </section>
-
-      <aside class="panel">
+      <aside class="panel panel-left">
         <h2>裁切并生成图层</h2>
         <div class="row">
           <label for="targetW">目标宽</label>
@@ -51,6 +34,39 @@
         <button id="exportBtn" type="button">导出 PNG（选中优先） (E)</button>
         <p class="tips">提示：滚轮可上下左右平移画布；中键也可拖动画布。缩放修饰键可在下方设置（默认 Alt/Option(⌥)+滚轮）。画布带像素标尺。框选后可拖动选框，Shift 锁定 1:1。支持一键去除仿 PNG 格子背景，也支持 Ctrl/Cmd+C 复制框选、Ctrl/Cmd+V 粘贴为新图层。按 Backspace 可删除框选内容（无框选时删除选中图层）。在画布中可用 Alt/Option+点击进行多图层点选。</p>
 
+        <h2>快捷键设置</h2>
+        <div class="row">
+          <label for="zoomModifierSelect">缩放键</label>
+          <select id="zoomModifierSelect">
+            <option value="Alt">Alt/Option(⌥)</option>
+            <option value="Ctrl">Ctrl</option>
+            <option value="Meta">Meta/Command(⌘)</option>
+            <option value="Shift">Shift</option>
+            <option value="None">无（直接滚轮缩放）</option>
+          </select>
+        </div>
+        <div id="shortcutList" class="shortcut-list"></div>
+        <button id="resetShortcutBtn" type="button">恢复默认快捷键</button>
+      </aside>
+
+      <section class="workspace">
+        <div class="toolbar">
+          <button id="cropModeBtn" type="button">开始框选 (C)</button>
+          <button id="clearCropBtn" type="button">清除框选 (X/Esc)</button>
+          <span id="statusText">拖入图片开始编辑</span>
+        </div>
+        <div class="canvas-shell">
+          <div class="ruler-corner"></div>
+          <canvas id="rulerTop" class="ruler-top"></canvas>
+          <canvas id="rulerLeft" class="ruler-left"></canvas>
+          <div class="canvas-wrap" id="dropZone">
+            <canvas id="stage"></canvas>
+            <div class="drop-hint" id="dropHint">拖入 PNG/JPG 图片到这里</div>
+          </div>
+        </div>
+      </section>
+
+      <aside class="panel panel-right">
         <h2>AI 生图</h2>
         <div class="row">
           <label for="aiProvider">Provider</label>
@@ -134,20 +150,6 @@
 
         <h2>素材候选区</h2>
         <div id="aiGallery" class="ai-gallery"></div>
-
-        <h2>快捷键设置</h2>
-        <div class="row">
-          <label for="zoomModifierSelect">缩放键</label>
-          <select id="zoomModifierSelect">
-            <option value="Alt">Alt/Option(⌥)</option>
-            <option value="Ctrl">Ctrl</option>
-            <option value="Meta">Meta/Command(⌘)</option>
-            <option value="Shift">Shift</option>
-            <option value="None">无（直接滚轮缩放）</option>
-          </select>
-        </div>
-        <div id="shortcutList" class="shortcut-list"></div>
-        <button id="resetShortcutBtn" type="button">恢复默认快捷键</button>
       </aside>
     </div>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,7 +24,7 @@ body {
 
 .app {
   display: grid;
-  grid-template-columns: 1fr 340px;
+  grid-template-columns: 320px minmax(0, 1fr) 360px;
   gap: 12px;
   height: 100%;
   padding: 12px;
@@ -139,6 +139,12 @@ body {
 .panel {
   padding: 12px;
   overflow: auto;
+  min-height: 0;
+}
+
+.panel-left,
+.panel-right {
+  min-width: 0;
 }
 
 h2 {
@@ -394,9 +400,26 @@ button:hover {
   box-shadow: 0 0 0 1px rgba(255, 183, 3, 0.35) inset;
 }
 
+
+@media (max-width: 1380px) {
+  .app {
+    grid-template-columns: 300px minmax(0, 1fr);
+    grid-template-rows: 1fr auto;
+  }
+
+  .panel-right {
+    grid-column: 1 / -1;
+    max-height: 40vh;
+  }
+}
+
 @media (max-width: 960px) {
   .app {
     grid-template-columns: 1fr;
-    grid-template-rows: 58vh auto;
+    grid-template-rows: auto 56vh auto;
+  }
+
+  .panel-right {
+    max-height: none;
   }
 }


### PR DESCRIPTION
## Summary
- restructure app shell into three clear areas: left panel (layer/crop/export/shortcuts), center workspace canvas, right panel (AI generation/task/gallery)
- move all existing non-AI operation controls to the left side panel
- keep all AI controls grouped exclusively in the right side panel
- update responsive layout rules so wide screens keep left/right separation and smaller screens remain usable

## Validation
- npm test
- npm run typecheck
- npm run build

Resolves #7
