### PR TITLE
fix: avoid implicit Gemini fallback in GPT-only mode

### DIFF
--- a/src/ai/__tests__/request-config.test.ts
+++ b/src/ai/__tests__/request-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveFallbackProvider } from "../request-config";
+
+describe("resolveFallbackProvider", () => {
+  it("does not auto-fallback when fallback provider is not explicitly selected", () => {
+    const fallback = resolveFallbackProvider({
+      primaryProvider: "openai",
+      enableFallback: true,
+      fallbackProvider: "",
+    });
+
+    expect(fallback).toBeUndefined();
+  });
+
+  it("returns explicit fallback provider when selected and different from primary", () => {
+    const fallback = resolveFallbackProvider({
+      primaryProvider: "openai",
+      enableFallback: true,
+      fallbackProvider: "gemini",
+    });
+
+    expect(fallback).toBe("gemini");
+  });
+
+  it("returns undefined when fallback is disabled", () => {
+    const fallback = resolveFallbackProvider({
+      primaryProvider: "openai",
+      enableFallback: false,
+      fallbackProvider: "gemini",
+    });
+
+    expect(fallback).toBeUndefined();
+  });
+});

--- a/src/ai/request-config.ts
+++ b/src/ai/request-config.ts
@@ -1,0 +1,20 @@
+import type { ProviderId } from "./types";
+
+export interface ResolveFallbackProviderInput {
+  primaryProvider: ProviderId;
+  enableFallback: boolean;
+  fallbackProvider: "" | ProviderId;
+}
+
+export function resolveFallbackProvider(input: ResolveFallbackProviderInput): ProviderId | undefined {
+  if (!input.enableFallback) {
+    return undefined;
+  }
+  if (!input.fallbackProvider) {
+    return undefined;
+  }
+  if (input.fallbackProvider === input.primaryProvider) {
+    return undefined;
+  }
+  return input.fallbackProvider;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import {
   writeBlobToDirectory,
 } from "./ai/fs-output";
 import { runWithFallback } from "./ai/provider-router";
+import { resolveFallbackProvider } from "./ai/request-config";
 import { createTaskRecord, patchTaskRecord } from "./ai/task-store";
 import { createGeminiAdapter } from "./ai/providers/gemini";
 import { createOpenAIAdapter } from "./ai/providers/openai";
@@ -1613,10 +1614,11 @@ function getSelectedSourceKind(): ImageSourceKind {
 }
 
 function makeProviderRequest(req: GenerateRequest): GenerateRequest {
-  const fallback = aiState.settings.enableFallback
-    ? (aiState.settings.fallbackProvider || (req.provider === "openai" ? "gemini" : "openai"))
-    : undefined;
-  const fallbackProvider = fallback && fallback !== req.provider ? fallback : undefined;
+  const fallbackProvider = resolveFallbackProvider({
+    primaryProvider: req.provider,
+    enableFallback: aiState.settings.enableFallback,
+    fallbackProvider: aiState.settings.fallbackProvider,
+  });
   return {
     ...req,
     fallbackProvider,


### PR DESCRIPTION
## Summary
- fix fallback selection logic so fallback only runs when explicitly configured by user
- remove implicit auto-fallback to opposite provider when fallback provider is empty
- add unit tests for fallback resolution behavior (explicit vs implicit)

## Validation
- npm test -- src/ai/__tests__/request-config.test.ts
- npm test
- npm run typecheck
- npm run build

Resolves #9
