### PR TITLE
fix: unblock text copy and OpenAI /v1 URL handling

### DIFF
--- a/src/__tests__/clipboard-shortcuts.test.ts
+++ b/src/__tests__/clipboard-shortcuts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveGlobalClipboardAction } from "../clipboard-shortcuts";
+
+describe("resolveGlobalClipboardAction", () => {
+  it("does not hijack Cmd/Ctrl+C when page text is selected", () => {
+    const action = resolveGlobalClipboardAction({
+      key: "c",
+      ctrlOrMeta: true,
+      altKey: false,
+      typing: false,
+      hasTextSelection: true,
+    });
+
+    expect(action).toBeNull();
+  });
+
+  it("keeps crop copy shortcut when no text is selected", () => {
+    const action = resolveGlobalClipboardAction({
+      key: "c",
+      ctrlOrMeta: true,
+      altKey: false,
+      typing: false,
+      hasTextSelection: false,
+    });
+
+    expect(action).toBe("copyCropSelection");
+  });
+
+  it("keeps crop paste shortcut behavior", () => {
+    const action = resolveGlobalClipboardAction({
+      key: "v",
+      ctrlOrMeta: true,
+      altKey: false,
+      typing: false,
+      hasTextSelection: true,
+    });
+
+    expect(action).toBe("pasteCropSelection");
+  });
+});

--- a/src/ai/__tests__/openai-provider.test.ts
+++ b/src/ai/__tests__/openai-provider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeOpenAIBaseUrl } from "../providers/openai";
+
+describe("normalizeOpenAIBaseUrl", () => {
+  it("keeps canonical base URL unchanged", () => {
+    expect(normalizeOpenAIBaseUrl("https://api.openai.com")).toBe("https://api.openai.com");
+  });
+
+  it("removes trailing slash", () => {
+    expect(normalizeOpenAIBaseUrl("https://api.openai.com/")).toBe("https://api.openai.com");
+  });
+
+  it("normalizes base URL that already includes /v1", () => {
+    expect(normalizeOpenAIBaseUrl("https://api.openai.com/v1")).toBe("https://api.openai.com");
+    expect(normalizeOpenAIBaseUrl("https://api.openai.com/v1/")).toBe("https://api.openai.com");
+  });
+});

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -6,8 +6,11 @@ export interface OpenAIConfig {
   baseUrl: string;
 }
 
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/$/, "");
+export function normalizeOpenAIBaseUrl(baseUrl: string): string {
+  const trimmed = (baseUrl || "https://api.openai.com").trim();
+  const noTrailingSlash = trimmed.replace(/\/+$/, "");
+  const noVersionSuffix = noTrailingSlash.replace(/\/v1$/i, "");
+  return noVersionSuffix || "https://api.openai.com";
 }
 
 async function ensureOk(response: Response): Promise<void> {
@@ -63,7 +66,7 @@ export function createOpenAIAdapter(getConfig: () => OpenAIConfig): ProviderAdap
         Authorization: `Bearer ${config.apiKey}`,
       };
 
-      const baseUrl = normalizeBaseUrl(config.baseUrl || "https://api.openai.com");
+      const baseUrl = normalizeOpenAIBaseUrl(config.baseUrl || "https://api.openai.com");
 
       if (req.mode === "text_to_image") {
         const response = await fetch(`${baseUrl}/v1/images/generations`, {

--- a/src/clipboard-shortcuts.ts
+++ b/src/clipboard-shortcuts.ts
@@ -1,0 +1,31 @@
+export type GlobalClipboardAction = "copyCropSelection" | "pasteCropSelection";
+
+export interface ResolveGlobalClipboardActionInput {
+  key: string;
+  ctrlOrMeta: boolean;
+  altKey: boolean;
+  typing: boolean;
+  hasTextSelection: boolean;
+}
+
+export function resolveGlobalClipboardAction(
+  input: ResolveGlobalClipboardActionInput,
+): GlobalClipboardAction | null {
+  if (input.typing || !input.ctrlOrMeta || input.altKey) {
+    return null;
+  }
+
+  const lowerKey = input.key.toLowerCase();
+  if (lowerKey === "c") {
+    if (input.hasTextSelection) {
+      return null;
+    }
+    return "copyCropSelection";
+  }
+
+  if (lowerKey === "v") {
+    return "pasteCropSelection";
+  }
+
+  return null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import "./styles.css";
+import { resolveGlobalClipboardAction } from "./clipboard-shortcuts";
 import { createGalleryItemsFromAssets, markSelectedSource } from "./ai/gallery-store";
 import {
   loadAiHistory,
@@ -2686,18 +2687,26 @@ window.addEventListener("keydown", (event: KeyboardEvent) => {
     return;
   }
 
-  if (!typing && (event.ctrlKey || event.metaKey) && !event.altKey) {
-    const lowerKey = event.key.toLowerCase();
-    if (lowerKey === "c") {
-      event.preventDefault();
-      copyCropBtn.click();
-      return;
-    }
-    if (lowerKey === "v") {
-      event.preventDefault();
-      pasteCropBtn.click();
-      return;
-    }
+  const selection = window.getSelection();
+  const hasTextSelection = Boolean(selection && !selection.isCollapsed && selection.toString().trim().length > 0);
+  const clipboardAction = resolveGlobalClipboardAction({
+    key: event.key,
+    ctrlOrMeta: event.ctrlKey || event.metaKey,
+    altKey: event.altKey,
+    typing,
+    hasTextSelection,
+  });
+
+  if (clipboardAction === "copyCropSelection") {
+    event.preventDefault();
+    copyCropBtn.click();
+    return;
+  }
+
+  if (clipboardAction === "pasteCropSelection") {
+    event.preventDefault();
+    pasteCropBtn.click();
+    return;
   }
 
   if (!typing && event.key === "Backspace") {


### PR DESCRIPTION
## Summary
- fix global clipboard shortcut handling to avoid hijacking Cmd/Ctrl+C when page text is selected
- keep existing crop copy/paste shortcuts behavior when no text selection exists
- normalize OpenAI base URL to support both `https://api.openai.com` and `https://api.openai.com/v1` without duplicate `/v1`
- add tests for clipboard shortcut resolution and OpenAI base URL normalization

## Validation
- npm test -- src/__tests__/clipboard-shortcuts.test.ts src/ai/__tests__/openai-provider.test.ts
- npm test
- npm run typecheck
- npm run build

Resolves #11
