### PR TITLE
feat: migrate AI providers to SDK integrations

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
           <select id="aiProvider">
             <option value="openai">OpenAI (GPT)</option>
             <option value="gemini">NanoBanana (Gemini)</option>
+            <option value="openrouter">OpenRouter</option>
           </select>
         </div>
         <div class="row">
@@ -128,6 +129,18 @@
             <input id="geminiModel" type="text" value="gemini-2.5-flash-image-preview" />
           </div>
           <div class="row">
+            <label for="openrouterApiKey">OpenRouter Key</label>
+            <input id="openrouterApiKey" type="password" autocomplete="off" placeholder="sk-or-v1-..." />
+          </div>
+          <div class="row">
+            <label for="openrouterBaseUrl">OpenRouter Base</label>
+            <input id="openrouterBaseUrl" type="text" value="https://openrouter.ai/api/v1" />
+          </div>
+          <div class="row">
+            <label for="openrouterModel">OpenRouter 模型</label>
+            <input id="openrouterModel" type="text" value="openai/gpt-5-image" />
+          </div>
+          <div class="row">
             <label for="aiOutputCount">张数</label>
             <input id="aiOutputCount" type="number" min="1" max="4" value="1" />
           </div>
@@ -141,6 +154,7 @@
               <option value="">不启用</option>
               <option value="openai">OpenAI</option>
               <option value="gemini">Gemini</option>
+              <option value="openrouter">OpenRouter</option>
             </select>
           </div>
         </details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,11 @@
   "packages": {
     "": {
       "name": "spcrop-gui",
+      "dependencies": {
+        "@google/genai": "^1.43.0",
+        "@openrouter/sdk": "^0.9.11",
+        "openai": "^6.25.0"
+      },
       "devDependencies": {
         "typescript": "^5.9.2",
         "vite": "^7.1.5",
@@ -453,12 +458,136 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.43.0.tgz",
+      "integrity": "sha512-hklCsJNdMlDM1IwcCVcGQFBg2izY0+t5BIGbRsxi2UnKi6AGKL7pqJqmBDNRbw0bYCs4y3NA7TB+fkKfP/Nrdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@openrouter/sdk": {
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.9.11.tgz",
+      "integrity": "sha512-BgFu6NcIJO4a9aVjr04y3kZ8pyM71j15I+bzfVAGEvxnj+KQNIkBYQGgwrG3D+aT1QpDKLki8btcQmpaxUas6A==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -842,6 +971,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -953,6 +1097,39 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -963,6 +1140,56 @@
         "node": ">=12"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -972,6 +1199,85 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1042,6 +1348,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1060,6 +1372,57 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1075,6 +1438,167 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.1.tgz",
+      "integrity": "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "7.1.3",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1084,6 +1608,36 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1104,6 +1658,44 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1114,6 +1706,71 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.25.0.tgz",
+      "integrity": "sha512-mEh6VZ2ds2AGGokWARo18aPISI1OhlgdEIC1ewhkZr8pSIT31dec0ecr9Nhxx0JlybyOgoAT1sWeKtwPZzJyww==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1171,6 +1828,54 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -1216,12 +1921,65 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1246,6 +2004,102 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1304,6 +2158,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -1458,6 +2318,30 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1473,6 +2357,127 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,10 @@
     "typescript": "^5.9.2",
     "vite": "^7.1.5",
     "vitest": "^4.0.18"
+  },
+  "dependencies": {
+    "@google/genai": "^1.43.0",
+    "@openrouter/sdk": "^0.9.11",
+    "openai": "^6.25.0"
   }
 }

--- a/src/ai/__tests__/gemini-provider.test.ts
+++ b/src/ai/__tests__/gemini-provider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeGeminiBaseUrl } from "../providers/gemini";
+
+describe("normalizeGeminiBaseUrl", () => {
+  it("keeps host-only base URL", () => {
+    expect(normalizeGeminiBaseUrl("https://generativelanguage.googleapis.com")).toEqual({
+      baseUrl: "https://generativelanguage.googleapis.com",
+    });
+  });
+
+  it("splits base URL and version when URL contains version suffix", () => {
+    expect(normalizeGeminiBaseUrl("https://generativelanguage.googleapis.com/v1beta")).toEqual({
+      baseUrl: "https://generativelanguage.googleapis.com",
+      apiVersion: "v1beta",
+    });
+  });
+});

--- a/src/ai/__tests__/openai-provider.test.ts
+++ b/src/ai/__tests__/openai-provider.test.ts
@@ -3,16 +3,16 @@ import { describe, expect, it } from "vitest";
 import { normalizeOpenAIBaseUrl } from "../providers/openai";
 
 describe("normalizeOpenAIBaseUrl", () => {
-  it("keeps canonical base URL unchanged", () => {
-    expect(normalizeOpenAIBaseUrl("https://api.openai.com")).toBe("https://api.openai.com");
+  it("adds /v1 for canonical API host", () => {
+    expect(normalizeOpenAIBaseUrl("https://api.openai.com")).toBe("https://api.openai.com/v1");
   });
 
   it("removes trailing slash", () => {
-    expect(normalizeOpenAIBaseUrl("https://api.openai.com/")).toBe("https://api.openai.com");
+    expect(normalizeOpenAIBaseUrl("https://api.openai.com/")).toBe("https://api.openai.com/v1");
   });
 
-  it("normalizes base URL that already includes /v1", () => {
-    expect(normalizeOpenAIBaseUrl("https://api.openai.com/v1")).toBe("https://api.openai.com");
-    expect(normalizeOpenAIBaseUrl("https://api.openai.com/v1/")).toBe("https://api.openai.com");
+  it("keeps base URL that already includes /v1", () => {
+    expect(normalizeOpenAIBaseUrl("https://api.openai.com/v1")).toBe("https://api.openai.com/v1");
+    expect(normalizeOpenAIBaseUrl("https://api.openai.com/v1/")).toBe("https://api.openai.com/v1");
   });
 });

--- a/src/ai/__tests__/openrouter-provider.test.ts
+++ b/src/ai/__tests__/openrouter-provider.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeOpenRouterBaseUrl } from "../providers/openrouter";
+
+describe("normalizeOpenRouterBaseUrl", () => {
+  it("uses canonical base with /api/v1", () => {
+    expect(normalizeOpenRouterBaseUrl("https://openrouter.ai")).toBe("https://openrouter.ai/api/v1");
+  });
+
+  it("keeps explicit /api/v1 unchanged", () => {
+    expect(normalizeOpenRouterBaseUrl("https://openrouter.ai/api/v1")).toBe("https://openrouter.ai/api/v1");
+  });
+});

--- a/src/ai/__tests__/provider-router.test.ts
+++ b/src/ai/__tests__/provider-router.test.ts
@@ -4,13 +4,18 @@ import type { GenerateRequest, GeneratedAsset, ProviderAdapter, ProviderId } fro
 import { runWithFallback } from "../provider-router";
 
 function makeRequest(provider: ProviderId): GenerateRequest {
+  const fallbackProvider: ProviderId = provider === "openai"
+    ? "gemini"
+    : provider === "gemini"
+      ? "openrouter"
+      : "openai";
   return {
     provider,
     mode: "text_to_image",
     prompt: "pixel fox",
     model: "model-a",
     outputCount: 1,
-    fallbackProvider: provider === "openai" ? "gemini" : "openai",
+    fallbackProvider,
   };
 }
 
@@ -25,6 +30,41 @@ function makeAsset(name: string): GeneratedAsset {
 }
 
 describe("runWithFallback", () => {
+  it("routes openrouter primary requests to the openrouter adapter", async () => {
+    const calls: string[] = [];
+    const openai: ProviderAdapter = {
+      generate: async () => {
+        calls.push("openai");
+        return [makeAsset("openai")];
+      },
+    };
+    const gemini: ProviderAdapter = {
+      generate: async () => {
+        calls.push("gemini");
+        return [makeAsset("gemini")];
+      },
+    };
+    const openrouter: ProviderAdapter = {
+      generate: async () => {
+        calls.push("openrouter");
+        return [makeAsset("openrouter")];
+      },
+    };
+
+    const result = await runWithFallback(
+      makeRequest("openrouter"),
+      {
+        openai,
+        gemini,
+        openrouter,
+      },
+      undefined,
+    );
+
+    expect(result.providerUsed).toBe("openrouter");
+    expect(calls).toEqual(["openrouter"]);
+  });
+
   it("returns primary provider result when primary succeeds", async () => {
     const calls: ProviderId[] = [];
     const openai: ProviderAdapter = {
@@ -39,8 +79,14 @@ describe("runWithFallback", () => {
         return [makeAsset("gemini")];
       },
     };
+    const openrouter: ProviderAdapter = {
+      generate: async () => {
+        calls.push("openrouter");
+        return [makeAsset("openrouter")];
+      },
+    };
 
-    const result = await runWithFallback(makeRequest("openai"), { openai, gemini });
+    const result = await runWithFallback(makeRequest("openai"), { openai, gemini, openrouter });
 
     expect(result.providerUsed).toBe("openai");
     expect(result.fallbackFrom).toBeNull();
@@ -62,8 +108,14 @@ describe("runWithFallback", () => {
         return [makeAsset("gemini")];
       },
     };
+    const openrouter: ProviderAdapter = {
+      generate: async () => {
+        calls.push("openrouter");
+        return [makeAsset("openrouter")];
+      },
+    };
 
-    const result = await runWithFallback(makeRequest("openai"), { openai, gemini });
+    const result = await runWithFallback(makeRequest("openai"), { openai, gemini, openrouter });
 
     expect(result.providerUsed).toBe("gemini");
     expect(result.fallbackFrom).toBe("openai");
@@ -79,6 +131,9 @@ describe("runWithFallback", () => {
     const gemini: ProviderAdapter = {
       generate: async () => [makeAsset("gemini")],
     };
+    const openrouter: ProviderAdapter = {
+      generate: async () => [makeAsset("openrouter")],
+    };
 
     await expect(
       runWithFallback(
@@ -86,7 +141,7 @@ describe("runWithFallback", () => {
           ...makeRequest("openai"),
           fallbackProvider: undefined,
         },
-        { openai, gemini },
+        { openai, gemini, openrouter },
       ),
     ).rejects.toThrow("primary failed");
   });

--- a/src/ai/__tests__/request-config.test.ts
+++ b/src/ai/__tests__/request-config.test.ts
@@ -23,6 +23,16 @@ describe("resolveFallbackProvider", () => {
     expect(fallback).toBe("gemini");
   });
 
+  it("supports openrouter as explicit fallback provider", () => {
+    const fallback = resolveFallbackProvider({
+      primaryProvider: "gemini",
+      enableFallback: true,
+      fallbackProvider: "openrouter",
+    });
+
+    expect(fallback).toBe("openrouter");
+  });
+
   it("returns undefined when fallback is disabled", () => {
     const fallback = resolveFallbackProvider({
       primaryProvider: "openai",

--- a/src/ai/provider-router.ts
+++ b/src/ai/provider-router.ts
@@ -1,10 +1,14 @@
 import type { ProviderAdapterMap, RunWithFallbackResult, GenerateRequest, ProviderId } from "./types";
 
 function getAdapter(provider: ProviderId, adapters: ProviderAdapterMap) {
-  if (provider === "openai") {
-    return adapters.openai;
+  switch (provider) {
+    case "openai":
+      return adapters.openai;
+    case "gemini":
+      return adapters.gemini;
+    default:
+      return adapters.openrouter;
   }
-  return adapters.gemini;
 }
 
 export async function runWithFallback(

--- a/src/ai/providers/gemini.ts
+++ b/src/ai/providers/gemini.ts
@@ -1,3 +1,5 @@
+import { GoogleGenAI, Modality } from "@google/genai";
+
 import { makeGeneratedAsset } from "../image-utils";
 import type { GenerateRequest, ProviderAdapter } from "../types";
 
@@ -14,8 +16,28 @@ interface GeminiPart {
   };
 }
 
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/$/, "");
+interface GeminiBaseUrlConfig {
+  baseUrl?: string;
+  apiVersion?: string;
+}
+
+const GEMINI_VERSION_SUFFIX_RE = /\/(v1alpha|v1beta|v1)$/i;
+
+export function normalizeGeminiBaseUrl(baseUrl: string): GeminiBaseUrlConfig {
+  const trimmed = (baseUrl || "").trim();
+  const noTrailingSlash = trimmed.replace(/\/+$/, "");
+  if (!noTrailingSlash) {
+    return {};
+  }
+  const versionMatch = noTrailingSlash.match(GEMINI_VERSION_SUFFIX_RE);
+  if (!versionMatch) {
+    return { baseUrl: noTrailingSlash };
+  }
+  const normalizedBaseUrl = noTrailingSlash.replace(GEMINI_VERSION_SUFFIX_RE, "");
+  return {
+    baseUrl: normalizedBaseUrl,
+    apiVersion: versionMatch[1].toLowerCase(),
+  };
 }
 
 function b64ToBlob(base64: string, mimeType: string): Blob {
@@ -27,18 +49,26 @@ function b64ToBlob(base64: string, mimeType: string): Blob {
   return new Blob([bytes], { type: mimeType });
 }
 
-async function ensureOk(response: Response): Promise<void> {
-  if (response.ok) {
-    return;
+async function blobToBase64(blob: Blob): Promise<string> {
+  const data = await blob.arrayBuffer();
+  const bytes = new Uint8Array(data);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
   }
-  let detail = "";
-  try {
-    const json = (await response.json()) as { error?: { message?: string } };
-    detail = json.error?.message ? `: ${json.error.message}` : "";
-  } catch {
-    // Ignore parsing failure.
+  return btoa(binary);
+}
+
+function toGeminiError(error: unknown): Error {
+  if (error && typeof error === "object" && "status" in error) {
+    const status = String((error as { status?: unknown }).status ?? "unknown");
+    const message = String((error as { message?: unknown }).message ?? "request failed");
+    return new Error(`Gemini request failed (${status}): ${message}`);
   }
-  throw new Error(`Gemini request failed (${response.status})${detail}`);
+  if (error instanceof Error) {
+    return new Error(`Gemini request failed: ${error.message}`);
+  }
+  return new Error("Gemini request failed");
 }
 
 function buildPromptText(req: GenerateRequest): string {
@@ -52,13 +82,21 @@ export function createGeminiAdapter(getConfig: () => GeminiConfig): ProviderAdap
   return {
     async generate(req: GenerateRequest, signal?: AbortSignal) {
       const config = getConfig();
-      if (!config.apiKey.trim()) {
+      const apiKey = config.apiKey.trim();
+      if (!apiKey) {
         throw new Error("Missing Gemini API key");
       }
 
-      const baseUrl = normalizeBaseUrl(config.baseUrl || "https://generativelanguage.googleapis.com");
-      const model = req.model;
-      const apiUrl = `${baseUrl}/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(config.apiKey)}`;
+      const base = normalizeGeminiBaseUrl(config.baseUrl);
+      const client = new GoogleGenAI({
+        apiKey,
+        apiVersion: base.apiVersion,
+        httpOptions: base.baseUrl
+          ? {
+            baseUrl: base.baseUrl,
+          }
+          : undefined,
+      });
 
       const parts: GeminiPart[] = [
         {
@@ -70,65 +108,52 @@ export function createGeminiAdapter(getConfig: () => GeminiConfig): ProviderAdap
         if (!req.imageSource) {
           throw new Error("Image source is required for image-to-image mode");
         }
-        const data = await req.imageSource.blob.arrayBuffer();
-        const bytes = new Uint8Array(data);
-        let binary = "";
-        for (const byte of bytes) {
-          binary += String.fromCharCode(byte);
-        }
         parts.push({
           inlineData: {
             mimeType: req.imageSource.mimeType || "image/png",
-            data: btoa(binary),
+            data: await blobToBase64(req.imageSource.blob),
           },
         });
       }
 
-      const response = await fetch(apiUrl, {
-        method: "POST",
-        signal,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
+      try {
+        const payload = await client.models.generateContent({
+          model: req.model,
           contents: [
             {
               role: "user",
               parts,
             },
           ],
-          generationConfig: {
-            responseModalities: ["TEXT", "IMAGE"],
+          config: {
+            responseModalities: [Modality.TEXT, Modality.IMAGE],
             candidateCount: Math.max(1, req.outputCount),
+            abortSignal: signal,
           },
-        }),
-      });
+        });
 
-      await ensureOk(response);
-
-      const payload = (await response.json()) as {
-        candidates?: Array<{ content?: { parts?: GeminiPart[] } }>;
-      };
-
-      const blobs: Blob[] = [];
-      for (const candidate of payload.candidates ?? []) {
-        for (const part of candidate.content?.parts ?? []) {
-          if (part.inlineData?.data) {
-            blobs.push(b64ToBlob(part.inlineData.data, part.inlineData.mimeType || "image/png"));
+        const blobs: Blob[] = [];
+        for (const candidate of payload.candidates ?? []) {
+          for (const part of candidate.content?.parts ?? []) {
+            if (part.inlineData?.data) {
+              blobs.push(b64ToBlob(part.inlineData.data, part.inlineData.mimeType || "image/png"));
+            }
           }
         }
-      }
 
-      if (blobs.length === 0) {
-        throw new Error("Gemini returned no images");
-      }
+        if (blobs.length === 0) {
+          throw new Error("Gemini returned no images");
+        }
 
-      const assets = [];
-      for (const blob of blobs) {
-        // eslint-disable-next-line no-await-in-loop
-        assets.push(await makeGeneratedAsset(blob));
+        const assets = [];
+        for (const blob of blobs) {
+          // eslint-disable-next-line no-await-in-loop
+          assets.push(await makeGeneratedAsset(blob));
+        }
+        return assets;
+      } catch (error) {
+        throw toGeminiError(error);
       }
-      return assets;
     },
   };
 }

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -1,3 +1,5 @@
+import OpenAI, { APIError } from "openai";
+
 import { makeGeneratedAsset } from "../image-utils";
 import type { GenerateRequest, ProviderAdapter } from "../types";
 
@@ -9,22 +11,23 @@ export interface OpenAIConfig {
 export function normalizeOpenAIBaseUrl(baseUrl: string): string {
   const trimmed = (baseUrl || "https://api.openai.com").trim();
   const noTrailingSlash = trimmed.replace(/\/+$/, "");
-  const noVersionSuffix = noTrailingSlash.replace(/\/v1$/i, "");
-  return noVersionSuffix || "https://api.openai.com";
+  if (!noTrailingSlash) {
+    return "https://api.openai.com/v1";
+  }
+  if (/\/v1$/i.test(noTrailingSlash)) {
+    return noTrailingSlash;
+  }
+  return `${noTrailingSlash}/v1`;
 }
 
-async function ensureOk(response: Response): Promise<void> {
-  if (response.ok) {
-    return;
+function toOpenAIError(error: unknown): Error {
+  if (error instanceof APIError) {
+    return new Error(`OpenAI request failed (${error.status ?? "unknown"}): ${error.message}`);
   }
-  let detail = "";
-  try {
-    const json = (await response.json()) as { error?: { message?: string } };
-    detail = json.error?.message ? `: ${json.error.message}` : "";
-  } catch {
-    // Ignore parsing failure.
+  if (error instanceof Error) {
+    return new Error(`OpenAI request failed: ${error.message}`);
   }
-  throw new Error(`OpenAI request failed (${response.status})${detail}`);
+  return new Error("OpenAI request failed");
 }
 
 function b64ToBlob(base64: string, mimeType: string): Blob {
@@ -36,7 +39,7 @@ function b64ToBlob(base64: string, mimeType: string): Blob {
   return new Blob([bytes], { type: mimeType });
 }
 
-async function responseDataToAssets(data: Array<{ b64_json?: string; url?: string }>): Promise<Blob[]> {
+async function responseDataToAssets(data: Array<{ b64_json?: string | null; url?: string | null }>): Promise<Blob[]> {
   const blobs: Blob[] = [];
   for (const item of data) {
     if (item.b64_json) {
@@ -46,7 +49,7 @@ async function responseDataToAssets(data: Array<{ b64_json?: string; url?: strin
     if (item.url) {
       const fetched = await fetch(item.url);
       if (!fetched.ok) {
-        throw new Error("OpenAI image URL download failed");
+        throw new Error(`OpenAI image URL download failed (${fetched.status})`);
       }
       blobs.push(await fetched.blob());
     }
@@ -58,37 +61,66 @@ export function createOpenAIAdapter(getConfig: () => OpenAIConfig): ProviderAdap
   return {
     async generate(req: GenerateRequest, signal?: AbortSignal) {
       const config = getConfig();
-      if (!config.apiKey.trim()) {
+      const apiKey = config.apiKey.trim();
+      if (!apiKey) {
         throw new Error("Missing OpenAI API key");
       }
 
-      const headers = {
-        Authorization: `Bearer ${config.apiKey}`,
-      };
+      const client = new OpenAI({
+        apiKey,
+        baseURL: normalizeOpenAIBaseUrl(config.baseUrl || "https://api.openai.com"),
+        dangerouslyAllowBrowser: true,
+      });
 
-      const baseUrl = normalizeOpenAIBaseUrl(config.baseUrl || "https://api.openai.com");
+      const prompt = req.negativePrompt
+        ? `${req.prompt}\n\nNegative prompt: ${req.negativePrompt}`
+        : req.prompt;
 
-      if (req.mode === "text_to_image") {
-        const response = await fetch(`${baseUrl}/v1/images/generations`, {
-          method: "POST",
-          signal,
-          headers: {
-            ...headers,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
+      try {
+        if (req.mode === "text_to_image") {
+          const response = await client.images.generate({
             model: req.model,
-            prompt: req.negativePrompt
-              ? `${req.prompt}\n\nNegative prompt: ${req.negativePrompt}`
-              : req.prompt,
+            prompt,
             n: Math.max(1, req.outputCount),
             response_format: "b64_json",
-          }),
+          }, {
+            signal,
+          });
+
+          const blobs = await responseDataToAssets(response.data ?? []);
+          if (blobs.length === 0) {
+            throw new Error("OpenAI returned no images");
+          }
+          const assets = [];
+          for (const blob of blobs) {
+            // eslint-disable-next-line no-await-in-loop
+            assets.push(await makeGeneratedAsset(blob));
+          }
+          return assets;
+        }
+
+        if (!req.imageSource) {
+          throw new Error("Image source is required for image-to-image mode");
+        }
+
+        const source = new File(
+          [req.imageSource.blob],
+          req.imageSource.name || "source.png",
+          {
+            type: req.imageSource.mimeType || req.imageSource.blob.type || "image/png",
+          },
+        );
+        const response = await client.images.edit({
+          model: req.model,
+          prompt,
+          n: Math.max(1, req.outputCount),
+          response_format: "b64_json",
+          image: source,
+        }, {
+          signal,
         });
 
-        await ensureOk(response);
-        const payload = (await response.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
-        const blobs = await responseDataToAssets(payload.data ?? []);
+        const blobs = await responseDataToAssets(response.data ?? []);
         if (blobs.length === 0) {
           throw new Error("OpenAI returned no images");
         }
@@ -98,41 +130,9 @@ export function createOpenAIAdapter(getConfig: () => OpenAIConfig): ProviderAdap
           assets.push(await makeGeneratedAsset(blob));
         }
         return assets;
+      } catch (error) {
+        throw toOpenAIError(error);
       }
-
-      if (!req.imageSource) {
-        throw new Error("Image source is required for image-to-image mode");
-      }
-
-      const formData = new FormData();
-      formData.append("model", req.model);
-      formData.append(
-        "prompt",
-        req.negativePrompt ? `${req.prompt}\n\nNegative prompt: ${req.negativePrompt}` : req.prompt,
-      );
-      formData.append("n", String(Math.max(1, req.outputCount)));
-      formData.append("response_format", "b64_json");
-      formData.append("image", req.imageSource.blob, req.imageSource.name || "source.png");
-
-      const response = await fetch(`${baseUrl}/v1/images/edits`, {
-        method: "POST",
-        signal,
-        headers,
-        body: formData,
-      });
-
-      await ensureOk(response);
-      const payload = (await response.json()) as { data?: Array<{ b64_json?: string; url?: string }> };
-      const blobs = await responseDataToAssets(payload.data ?? []);
-      if (blobs.length === 0) {
-        throw new Error("OpenAI returned no images");
-      }
-      const assets = [];
-      for (const blob of blobs) {
-        // eslint-disable-next-line no-await-in-loop
-        assets.push(await makeGeneratedAsset(blob));
-      }
-      return assets;
     },
   };
 }

--- a/src/ai/providers/openrouter.ts
+++ b/src/ai/providers/openrouter.ts
@@ -1,0 +1,166 @@
+import { OpenRouter } from "@openrouter/sdk";
+
+import { dataUrlToBlob, makeGeneratedAsset } from "../image-utils";
+import type { GenerateRequest, ProviderAdapter } from "../types";
+
+export interface OpenRouterConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+type OpenRouterUserContent = string | Array<
+  | { type: "text"; text: string }
+  | { type: "image_url"; imageUrl: { url: string } }
+>;
+
+export function normalizeOpenRouterBaseUrl(baseUrl: string): string {
+  const trimmed = (baseUrl || "https://openrouter.ai/api/v1").trim();
+  const noTrailingSlash = trimmed.replace(/\/+$/, "");
+  if (!noTrailingSlash) {
+    return "https://openrouter.ai/api/v1";
+  }
+  if (/\/api\/v1$/i.test(noTrailingSlash) || /\/v1$/i.test(noTrailingSlash)) {
+    return noTrailingSlash;
+  }
+  if (/\/api$/i.test(noTrailingSlash)) {
+    return `${noTrailingSlash}/v1`;
+  }
+  return `${noTrailingSlash}/api/v1`;
+}
+
+function buildPromptText(req: GenerateRequest): string {
+  if (!req.negativePrompt) {
+    return req.prompt;
+  }
+  return `${req.prompt}\n\nNegative prompt: ${req.negativePrompt}`;
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result);
+        return;
+      }
+      reject(new Error("Failed to read image source"));
+    };
+    reader.onerror = () => reject(new Error("Failed to read image source"));
+    reader.readAsDataURL(blob);
+  });
+}
+
+async function imageUrlToBlob(url: string): Promise<Blob> {
+  if (url.startsWith("data:")) {
+    return dataUrlToBlob(url);
+  }
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`OpenRouter image URL download failed (${response.status})`);
+  }
+  return await response.blob();
+}
+
+function toOpenRouterError(error: unknown): Error {
+  if (error && typeof error === "object" && "statusCode" in error) {
+    const statusCode = String((error as { statusCode?: unknown }).statusCode ?? "unknown");
+    const message = String((error as { message?: unknown }).message ?? "request failed");
+    return new Error(`OpenRouter request failed (${statusCode}): ${message}`);
+  }
+  if (error instanceof Error) {
+    return new Error(`OpenRouter request failed: ${error.message}`);
+  }
+  return new Error("OpenRouter request failed");
+}
+
+export function createOpenRouterAdapter(getConfig: () => OpenRouterConfig): ProviderAdapter {
+  return {
+    async generate(req: GenerateRequest, signal?: AbortSignal) {
+      const config = getConfig();
+      const apiKey = config.apiKey.trim();
+      if (!apiKey) {
+        throw new Error("Missing OpenRouter API key");
+      }
+
+      const client = new OpenRouter({
+        apiKey,
+        serverURL: normalizeOpenRouterBaseUrl(config.baseUrl),
+      });
+
+      const prompt = buildPromptText(req);
+      const runs = Math.max(1, req.outputCount);
+      const blobs: Blob[] = [];
+
+      try {
+        let sourceImageDataUrl: string | undefined;
+        if (req.mode === "image_to_image") {
+          if (!req.imageSource) {
+            throw new Error("Image source is required for image-to-image mode");
+          }
+          sourceImageDataUrl = await blobToDataUrl(req.imageSource.blob);
+        }
+
+        for (let i = 0; i < runs; i++) {
+          const content: OpenRouterUserContent = sourceImageDataUrl
+            ? [
+              { type: "text", text: prompt },
+              { type: "image_url", imageUrl: { url: sourceImageDataUrl } },
+            ]
+            : prompt;
+
+          // eslint-disable-next-line no-await-in-loop
+          const response = await client.chat.send({
+            chatGenerationParams: {
+              model: req.model,
+              stream: false,
+              modalities: ["image"],
+              messages: [
+                {
+                  role: "user",
+                  content,
+                },
+              ],
+            },
+          }, {
+            signal,
+          });
+
+          const imageUrls: string[] = [];
+          for (const choice of response.choices ?? []) {
+            for (const image of choice.message.images ?? []) {
+              if (image.imageUrl?.url) {
+                imageUrls.push(image.imageUrl.url);
+              }
+            }
+          }
+
+          for (const url of imageUrls) {
+            // eslint-disable-next-line no-await-in-loop
+            const blob = await imageUrlToBlob(url);
+            blobs.push(blob);
+            if (blobs.length >= runs) {
+              break;
+            }
+          }
+          if (blobs.length >= runs) {
+            break;
+          }
+        }
+      } catch (error) {
+        throw toOpenRouterError(error);
+      }
+
+      if (blobs.length === 0) {
+        throw new Error("OpenRouter returned no images");
+      }
+
+      const assets = [];
+      for (const blob of blobs) {
+        // eslint-disable-next-line no-await-in-loop
+        assets.push(await makeGeneratedAsset(blob));
+      }
+      return assets;
+    },
+  };
+}

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,4 +1,4 @@
-export type ProviderId = "openai" | "gemini";
+export type ProviderId = "openai" | "gemini" | "openrouter";
 
 export type GenerationMode = "text_to_image" | "image_to_image";
 
@@ -55,6 +55,7 @@ export interface ProviderAdapter {
 export interface ProviderAdapterMap {
   openai: ProviderAdapter;
   gemini: ProviderAdapter;
+  openrouter: ProviderAdapter;
 }
 
 export interface RunWithFallbackResult {
@@ -70,6 +71,9 @@ export interface AiSettings {
   geminiApiKey: string;
   geminiBaseUrl: string;
   geminiModel: string;
+  openrouterApiKey: string;
+  openrouterBaseUrl: string;
+  openrouterModel: string;
   enableFallback: boolean;
   fallbackProvider: "" | ProviderId;
   outputCount: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { resolveFallbackProvider } from "./ai/request-config";
 import { createTaskRecord, patchTaskRecord } from "./ai/task-store";
 import { createGeminiAdapter } from "./ai/providers/gemini";
 import { createOpenAIAdapter } from "./ai/providers/openai";
+import { createOpenRouterAdapter } from "./ai/providers/openrouter";
 import type {
   AiSettings,
   GalleryItem,
@@ -126,6 +127,9 @@ const DEFAULT_AI_SETTINGS: AiSettings = {
   geminiApiKey: "",
   geminiBaseUrl: "https://generativelanguage.googleapis.com",
   geminiModel: "gemini-2.5-flash-image-preview",
+  openrouterApiKey: "",
+  openrouterBaseUrl: "https://openrouter.ai/api/v1",
+  openrouterModel: "openai/gpt-5-image",
   enableFallback: true,
   fallbackProvider: "",
   outputCount: 1,
@@ -249,6 +253,9 @@ const openaiModelInput = mustGet<HTMLInputElement>("openaiModel");
 const geminiApiKeyInput = mustGet<HTMLInputElement>("geminiApiKey");
 const geminiBaseUrlInput = mustGet<HTMLInputElement>("geminiBaseUrl");
 const geminiModelInput = mustGet<HTMLInputElement>("geminiModel");
+const openrouterApiKeyInput = mustGet<HTMLInputElement>("openrouterApiKey");
+const openrouterBaseUrlInput = mustGet<HTMLInputElement>("openrouterBaseUrl");
+const openrouterModelInput = mustGet<HTMLInputElement>("openrouterModel");
 const aiOutputCountInput = mustGet<HTMLInputElement>("aiOutputCount");
 const enableFallbackInput = mustGet<HTMLInputElement>("enableFallback");
 const fallbackProviderSelect = mustGet<HTMLSelectElement>("fallbackProvider");
@@ -1533,7 +1540,7 @@ function downloadBlob(blob: Blob, filename: string): void {
 }
 
 function isProviderId(value: string): value is ProviderId {
-  return value === "openai" || value === "gemini";
+  return value === "openai" || value === "gemini" || value === "openrouter";
 }
 
 function isGenerationMode(value: string): value is GenerationMode {
@@ -1556,7 +1563,7 @@ function loadAiSettings(): void {
       ...DEFAULT_AI_SETTINGS,
       ...parsed,
       outputCount: clamp(Number(parsed.outputCount ?? DEFAULT_AI_SETTINGS.outputCount), 1, 4),
-      fallbackProvider: parsed.fallbackProvider === "openai" || parsed.fallbackProvider === "gemini"
+      fallbackProvider: parsed.fallbackProvider === "openai" || parsed.fallbackProvider === "gemini" || parsed.fallbackProvider === "openrouter"
         ? parsed.fallbackProvider
         : "",
     };
@@ -1580,6 +1587,9 @@ function syncAiSettingsToUI(): void {
   geminiApiKeyInput.value = aiState.settings.geminiApiKey;
   geminiBaseUrlInput.value = aiState.settings.geminiBaseUrl;
   geminiModelInput.value = aiState.settings.geminiModel;
+  openrouterApiKeyInput.value = aiState.settings.openrouterApiKey;
+  openrouterBaseUrlInput.value = aiState.settings.openrouterBaseUrl;
+  openrouterModelInput.value = aiState.settings.openrouterModel;
   aiOutputCountInput.value = String(aiState.settings.outputCount);
   enableFallbackInput.checked = aiState.settings.enableFallback;
   fallbackProviderSelect.value = aiState.settings.fallbackProvider;
@@ -1592,6 +1602,9 @@ function syncAiSettingsFromUI(): void {
   aiState.settings.geminiApiKey = geminiApiKeyInput.value.trim();
   aiState.settings.geminiBaseUrl = geminiBaseUrlInput.value.trim() || DEFAULT_AI_SETTINGS.geminiBaseUrl;
   aiState.settings.geminiModel = geminiModelInput.value.trim() || DEFAULT_AI_SETTINGS.geminiModel;
+  aiState.settings.openrouterApiKey = openrouterApiKeyInput.value.trim();
+  aiState.settings.openrouterBaseUrl = openrouterBaseUrlInput.value.trim() || DEFAULT_AI_SETTINGS.openrouterBaseUrl;
+  aiState.settings.openrouterModel = openrouterModelInput.value.trim() || DEFAULT_AI_SETTINGS.openrouterModel;
   aiState.settings.outputCount = clamp(Number(aiOutputCountInput.value) || 1, 1, 4);
   aiState.settings.enableFallback = enableFallbackInput.checked;
   const fallbackValue = fallbackProviderSelect.value;
@@ -1634,6 +1647,11 @@ const openaiAdapter = createOpenAIAdapter(() => ({
 const geminiAdapter = createGeminiAdapter(() => ({
   apiKey: aiState.settings.geminiApiKey,
   baseUrl: aiState.settings.geminiBaseUrl,
+}));
+
+const openrouterAdapter = createOpenRouterAdapter(() => ({
+  apiKey: aiState.settings.openrouterApiKey,
+  baseUrl: aiState.settings.openrouterBaseUrl,
 }));
 
 function refreshOutputDirStatus(): void {
@@ -1920,7 +1938,11 @@ async function createGenerateRequestFromUI(): Promise<GenerateRequest> {
     imageSource = await resolveImageSource(sourceKind);
   }
 
-  const model = provider === "openai" ? aiState.settings.openaiModel : aiState.settings.geminiModel;
+  const model = provider === "openai"
+    ? aiState.settings.openaiModel
+    : provider === "gemini"
+      ? aiState.settings.geminiModel
+      : aiState.settings.openrouterModel;
   const request = makeProviderRequest({
     provider,
     mode,
@@ -1951,7 +1973,11 @@ async function runGenerateTask(request: GenerateRequest): Promise<void> {
   aiState.taskAbortControllers.set(baseTask.id, controller);
 
   try {
-    const result = await runWithFallback(request, { openai: openaiAdapter, gemini: geminiAdapter }, controller.signal);
+    const result = await runWithFallback(
+      request,
+      { openai: openaiAdapter, gemini: geminiAdapter, openrouter: openrouterAdapter },
+      controller.signal,
+    );
     const outputFiles: string[] = [];
     for (let i = 0; i < result.assets.length; i++) {
       const asset = result.assets[i];
@@ -2292,6 +2318,9 @@ aiSourceKindSelect.addEventListener("change", () => {
   geminiApiKeyInput,
   geminiBaseUrlInput,
   geminiModelInput,
+  openrouterApiKeyInput,
+  openrouterBaseUrlInput,
+  openrouterModelInput,
   aiOutputCountInput,
   enableFallbackInput,
   fallbackProviderSelect,


### PR DESCRIPTION
## Summary
- migrate OpenAI image generation/editing from raw HTTP fetch to the official `openai` TypeScript SDK
- migrate Gemini generation from raw HTTP fetch to the official `@google/genai` SDK and keep image output parsing
- add OpenRouter provider via `@openrouter/sdk` with UI/config support and fallback routing integration
- extend provider types/settings/routing/tests for three providers (`openai`, `gemini`, `openrouter`)

## Validation
- `npm run test`
- `npm run typecheck`
- `npm run build`

Resolves #13
