### PR TITLE
feat: optimize AI settings modal, output directory restore, and task list text

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,64 +100,9 @@
           <textarea id="aiNegativePrompt" rows="2" placeholder="可选：不希望出现的内容"></textarea>
         </div>
         <button id="generateAiBtn" type="button">生成 AI 图片</button>
+        <button id="openAiSettingsBtn" type="button">打开 AI 设置</button>
         <button id="chooseOutputDirBtn" type="button">选择输出目录</button>
         <div id="outputDirStatus" class="mini-status">输出目录：未设置（将回退为下载）</div>
-        <details id="aiSettingsDetails" class="ai-settings">
-          <summary>AI 设置（密钥/模型/回退）</summary>
-          <div class="row">
-            <label for="openaiApiKey">OpenAI Key</label>
-            <input id="openaiApiKey" type="password" autocomplete="off" placeholder="sk-..." />
-          </div>
-          <div class="row">
-            <label for="openaiBaseUrl">OpenAI Base</label>
-            <input id="openaiBaseUrl" type="text" value="https://api.openai.com" />
-          </div>
-          <div class="row">
-            <label for="openaiModel">OpenAI 模型</label>
-            <input id="openaiModel" type="text" value="gpt-image-1" />
-          </div>
-          <div class="row">
-            <label for="geminiApiKey">Gemini Key</label>
-            <input id="geminiApiKey" type="password" autocomplete="off" placeholder="AIza..." />
-          </div>
-          <div class="row">
-            <label for="geminiBaseUrl">Gemini Base</label>
-            <input id="geminiBaseUrl" type="text" value="https://generativelanguage.googleapis.com" />
-          </div>
-          <div class="row">
-            <label for="geminiModel">Gemini 模型</label>
-            <input id="geminiModel" type="text" value="gemini-2.5-flash-image-preview" />
-          </div>
-          <div class="row">
-            <label for="openrouterApiKey">OpenRouter Key</label>
-            <input id="openrouterApiKey" type="password" autocomplete="off" placeholder="sk-or-v1-..." />
-          </div>
-          <div class="row">
-            <label for="openrouterBaseUrl">OpenRouter Base</label>
-            <input id="openrouterBaseUrl" type="text" value="https://openrouter.ai/api/v1" />
-          </div>
-          <div class="row">
-            <label for="openrouterModel">OpenRouter 模型</label>
-            <input id="openrouterModel" type="text" value="openai/gpt-5-image" />
-          </div>
-          <div class="row">
-            <label for="aiOutputCount">张数</label>
-            <input id="aiOutputCount" type="number" min="1" max="4" value="1" />
-          </div>
-          <div class="row">
-            <label for="enableFallback">回退重试</label>
-            <input id="enableFallback" type="checkbox" checked />
-          </div>
-          <div class="row">
-            <label for="fallbackProvider">回退 Provider</label>
-            <select id="fallbackProvider">
-              <option value="">不启用</option>
-              <option value="openai">OpenAI</option>
-              <option value="gemini">Gemini</option>
-              <option value="openrouter">OpenRouter</option>
-            </select>
-          </div>
-        </details>
 
         <h2>AI 任务</h2>
         <div id="aiTaskList" class="ai-task-list"></div>
@@ -166,6 +111,68 @@
         <div id="aiGallery" class="ai-gallery"></div>
       </aside>
     </div>
+
+    <dialog id="aiSettingsModal" class="ai-settings-modal">
+      <form method="dialog" class="ai-settings-modal-content">
+        <div class="ai-settings-modal-header">
+          <h2>AI 设置</h2>
+          <button id="closeAiSettingsBtn" type="button">关闭</button>
+        </div>
+        <div class="row">
+          <label for="openaiApiKey">OpenAI Key</label>
+          <input id="openaiApiKey" type="password" autocomplete="off" placeholder="sk-..." />
+        </div>
+        <div class="row">
+          <label for="openaiBaseUrl">OpenAI Base</label>
+          <input id="openaiBaseUrl" type="text" value="https://api.openai.com" />
+        </div>
+        <div class="row">
+          <label for="openaiModel">OpenAI 模型</label>
+          <input id="openaiModel" type="text" value="gpt-image-1" />
+        </div>
+        <div class="row">
+          <label for="geminiApiKey">Gemini Key</label>
+          <input id="geminiApiKey" type="password" autocomplete="off" placeholder="AIza..." />
+        </div>
+        <div class="row">
+          <label for="geminiBaseUrl">Gemini Base</label>
+          <input id="geminiBaseUrl" type="text" value="https://generativelanguage.googleapis.com" />
+        </div>
+        <div class="row">
+          <label for="geminiModel">Gemini 模型</label>
+          <input id="geminiModel" type="text" value="gemini-2.5-flash-image-preview" />
+        </div>
+        <div class="row">
+          <label for="openrouterApiKey">OpenRouter Key</label>
+          <input id="openrouterApiKey" type="password" autocomplete="off" placeholder="sk-or-v1-..." />
+        </div>
+        <div class="row">
+          <label for="openrouterBaseUrl">OpenRouter Base</label>
+          <input id="openrouterBaseUrl" type="text" value="https://openrouter.ai/api/v1" />
+        </div>
+        <div class="row">
+          <label for="openrouterModel">OpenRouter 模型</label>
+          <input id="openrouterModel" type="text" value="openai/gpt-5-image" />
+        </div>
+        <div class="row">
+          <label for="aiOutputCount">张数</label>
+          <input id="aiOutputCount" type="number" min="1" max="4" value="1" />
+        </div>
+        <div class="row">
+          <label for="enableFallback">回退重试</label>
+          <input id="enableFallback" type="checkbox" checked />
+        </div>
+        <div class="row">
+          <label for="fallbackProvider">回退 Provider</label>
+          <select id="fallbackProvider">
+            <option value="">不启用</option>
+            <option value="openai">OpenAI</option>
+            <option value="gemini">Gemini</option>
+            <option value="openrouter">OpenRouter</option>
+          </select>
+        </div>
+      </form>
+    </dialog>
 
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/ai/fs-output.ts
+++ b/src/ai/fs-output.ts
@@ -48,6 +48,12 @@ export async function ensureDirectoryPermission(handle: FileSystemDirectoryHandl
   return requested === "granted";
 }
 
+export async function queryDirectoryPermission(handle: FileSystemDirectoryHandle): Promise<boolean> {
+  const opts: FileSystemHandlePermissionDescriptor = { mode: "readwrite" };
+  const queried = await handle.queryPermission(opts);
+  return queried === "granted";
+}
+
 export async function writeBlobToDirectory(
   handle: FileSystemDirectoryHandle,
   blob: Blob,

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import {
   downloadBlobFallback,
   ensureDirectoryPermission,
   formatOutputFilename,
+  queryDirectoryPermission,
   selectOutputDirectory,
   supportsDirectoryPicker,
   writeBlobToDirectory,
@@ -243,10 +244,13 @@ const aiSourceKindSelect = mustGet<HTMLSelectElement>("aiSourceKind");
 const aiPromptInput = mustGet<HTMLTextAreaElement>("aiPrompt");
 const aiNegativePromptInput = mustGet<HTMLTextAreaElement>("aiNegativePrompt");
 const generateAiBtn = mustGet<HTMLButtonElement>("generateAiBtn");
+const openAiSettingsBtn = mustGet<HTMLButtonElement>("openAiSettingsBtn");
 const chooseOutputDirBtn = mustGet<HTMLButtonElement>("chooseOutputDirBtn");
 const outputDirStatus = mustGet<HTMLDivElement>("outputDirStatus");
 const aiTaskList = mustGet<HTMLDivElement>("aiTaskList");
 const aiGallery = mustGet<HTMLDivElement>("aiGallery");
+const aiSettingsModal = mustGet<HTMLDialogElement>("aiSettingsModal");
+const closeAiSettingsBtn = mustGet<HTMLButtonElement>("closeAiSettingsBtn");
 const openaiApiKeyInput = mustGet<HTMLInputElement>("openaiApiKey");
 const openaiBaseUrlInput = mustGet<HTMLInputElement>("openaiBaseUrl");
 const openaiModelInput = mustGet<HTMLInputElement>("openaiModel");
@@ -2049,7 +2053,7 @@ async function restoreAiState(): Promise<void> {
     const handle = await loadOutputDirectoryHandle();
     if (handle) {
       aiState.outputDirHandle = handle;
-      aiState.outputDirReady = await ensureDirectoryPermission(handle);
+      aiState.outputDirReady = await queryDirectoryPermission(handle);
     }
   } catch {
     aiState.outputDirHandle = null;
@@ -2309,6 +2313,25 @@ aiModeSelect.addEventListener("change", () => {
 
 aiSourceKindSelect.addEventListener("change", () => {
   aiState.selectedSourceKind = getSelectedSourceKind();
+});
+
+openAiSettingsBtn.addEventListener("click", () => {
+  aiSettingsModal.showModal();
+});
+
+closeAiSettingsBtn.addEventListener("click", () => {
+  aiSettingsModal.close();
+});
+
+aiSettingsModal.addEventListener("click", (event) => {
+  const rect = aiSettingsModal.getBoundingClientRect();
+  const inside = rect.top <= event.clientY
+    && event.clientY <= rect.top + rect.height
+    && rect.left <= event.clientX
+    && event.clientX <= rect.left + rect.width;
+  if (!inside) {
+    aiSettingsModal.close();
+  }
 });
 
 [

--- a/src/styles.css
+++ b/src/styles.css
@@ -327,13 +327,13 @@ button:hover {
 }
 
 .ai-task-title {
-  font-size: 12px;
+  font-size: 16px;
   font-weight: 600;
   margin-bottom: 4px;
 }
 
 .ai-task-meta {
-  font-size: 11px;
+  font-size: 15px;
   color: var(--muted);
   line-height: 1.35;
 }
@@ -348,7 +348,7 @@ button:hover {
   width: auto;
   margin: 0;
   padding: 4px 8px;
-  font-size: 11px;
+  font-size: 15px;
 }
 
 .ai-gallery {
@@ -398,6 +398,42 @@ button:hover {
 .shortcut-key.capturing {
   border-color: #ffb703;
   box-shadow: 0 0 0 1px rgba(255, 183, 3, 0.35) inset;
+}
+
+.ai-settings-modal {
+  width: min(640px, calc(100vw - 24px));
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--panel);
+  color: var(--text);
+  padding: 0;
+}
+
+.ai-settings-modal::backdrop {
+  background: rgba(8, 12, 20, 0.72);
+}
+
+.ai-settings-modal-content {
+  margin: 0;
+  padding: 12px;
+}
+
+.ai-settings-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.ai-settings-modal-header h2 {
+  margin: 0;
+}
+
+.ai-settings-modal-header button {
+  width: auto;
+  margin: 0;
+  padding: 6px 10px;
 }
 
 


### PR DESCRIPTION
## Summary
- move AI settings from right sidebar into a modal dialog to free panel space
- preserve output directory handle on restart without auto-requesting permission at startup (query only)
- increase AI task list typography by +4px for better readability

## Validation
- `npm run test`
- `npm run typecheck`
- `npm run build`

Resolves #15
