### PR TITLE
fix: OpenRouter image responses parsed correctly

### DIFF
--- a/src/ai/__tests__/openrouter-provider.test.ts
+++ b/src/ai/__tests__/openrouter-provider.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeOpenRouterBaseUrl } from "../providers/openrouter";
+import {
+  collectImageUrlsFromChatResponse,
+  normalizeOpenRouterBaseUrl,
+} from "../providers/openrouter";
 
 describe("normalizeOpenRouterBaseUrl", () => {
   it("uses canonical base with /api/v1", () => {
@@ -9,5 +12,75 @@ describe("normalizeOpenRouterBaseUrl", () => {
 
   it("keeps explicit /api/v1 unchanged", () => {
     expect(normalizeOpenRouterBaseUrl("https://openrouter.ai/api/v1")).toBe("https://openrouter.ai/api/v1");
+  });
+});
+
+describe("collectImageUrlsFromChatResponse", () => {
+  it("extracts URLs from message.images in both camelCase and snake_case forms", () => {
+    const urls = collectImageUrlsFromChatResponse({
+      choices: [
+        {
+          message: {
+            images: [
+              { imageUrl: { url: "https://example.com/a.png" } },
+              { image_url: { url: "https://example.com/b.png" } },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(urls).toEqual([
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+    ]);
+  });
+
+  it("extracts URLs from image parts in message.content", () => {
+    const urls = collectImageUrlsFromChatResponse({
+      choices: [
+        {
+          message: {
+            content: [
+              { type: "text", text: "ok" },
+              { type: "image_url", imageUrl: { url: "https://example.com/c.png" } },
+              { type: "image_url", image_url: { url: "https://example.com/d.png" } },
+              { type: "input_image", imageUrl: "https://example.com/e.png" },
+              { type: "output_image", url: "https://example.com/f.png" },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(urls).toEqual([
+      "https://example.com/c.png",
+      "https://example.com/d.png",
+      "https://example.com/e.png",
+      "https://example.com/f.png",
+    ]);
+  });
+
+  it("extracts URLs from image generation tool-call style payloads", () => {
+    const urls = collectImageUrlsFromChatResponse({
+      choices: [
+        {
+          message: {
+            toolCalls: [
+              { type: "image_generation_call", result: "https://example.com/g.png" },
+              { type: "function_call", result: "ignore me" },
+            ],
+            tool_calls: [
+              { type: "image_generation_call", result: "https://example.com/h.png" },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(urls).toEqual([
+      "https://example.com/g.png",
+      "https://example.com/h.png",
+    ]);
   });
 });

--- a/src/ai/providers/openrouter.ts
+++ b/src/ai/providers/openrouter.ts
@@ -8,6 +8,8 @@ export interface OpenRouterConfig {
   baseUrl: string;
 }
 
+type UnknownRecord = Record<string, unknown>;
+
 type OpenRouterUserContent = string | Array<
   | { type: "text"; text: string }
   | { type: "image_url"; imageUrl: { url: string } }
@@ -33,6 +35,139 @@ function buildPromptText(req: GenerateRequest): string {
     return req.prompt;
   }
   return `${req.prompt}\n\nNegative prompt: ${req.negativePrompt}`;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return value !== null && typeof value === "object";
+}
+
+function toNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readUrlFromUnknown(value: unknown): string | undefined {
+  const direct = toNonEmptyString(value);
+  if (direct) {
+    return direct;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const url = toNonEmptyString(value.url);
+  if (url) {
+    return url;
+  }
+
+  const nestedCamel = readUrlFromUnknown(value.imageUrl);
+  if (nestedCamel) {
+    return nestedCamel;
+  }
+  return readUrlFromUnknown(value.image_url);
+}
+
+function collectUrlsFromMessageContent(content: unknown, out: Set<string>): void {
+  if (!Array.isArray(content)) {
+    return;
+  }
+  for (const part of content) {
+    if (!isRecord(part)) {
+      continue;
+    }
+    const partType = toNonEmptyString(part.type);
+    if (partType && !partType.includes("image")) {
+      continue;
+    }
+    const url =
+      readUrlFromUnknown(part.imageUrl)
+      ?? readUrlFromUnknown(part.image_url)
+      ?? readUrlFromUnknown(part.url)
+      ?? readUrlFromUnknown(part.result);
+    if (url) {
+      out.add(url);
+    }
+  }
+}
+
+function collectUrlsFromMessageImages(images: unknown, out: Set<string>): void {
+  if (!Array.isArray(images)) {
+    return;
+  }
+  for (const image of images) {
+    const url = readUrlFromUnknown(image);
+    if (url) {
+      out.add(url);
+    }
+  }
+}
+
+function collectUrlsFromToolCalls(toolCalls: unknown, out: Set<string>): void {
+  if (!Array.isArray(toolCalls)) {
+    return;
+  }
+  for (const call of toolCalls) {
+    if (!isRecord(call) || toNonEmptyString(call.type) !== "image_generation_call") {
+      continue;
+    }
+    const url =
+      readUrlFromUnknown(call.result)
+      ?? readUrlFromUnknown(call.imageUrl)
+      ?? readUrlFromUnknown(call.image_url)
+      ?? readUrlFromUnknown(call.url);
+    if (url) {
+      out.add(url);
+    }
+  }
+}
+
+function collectUrlsFromResponsesOutput(output: unknown, out: Set<string>): void {
+  if (!Array.isArray(output)) {
+    return;
+  }
+  for (const item of output) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    const itemType = toNonEmptyString(item.type);
+    if (itemType === "image_generation_call") {
+      const url = readUrlFromUnknown(item.result) ?? readUrlFromUnknown(item.imageUrl);
+      if (url) {
+        out.add(url);
+      }
+      continue;
+    }
+    if (itemType === "message") {
+      collectUrlsFromMessageContent(item.content, out);
+    }
+  }
+}
+
+export function collectImageUrlsFromChatResponse(response: unknown): string[] {
+  if (!isRecord(response)) {
+    return [];
+  }
+
+  const imageUrls = new Set<string>();
+  const choices = Array.isArray(response.choices) ? response.choices : [];
+  for (const choice of choices) {
+    if (!isRecord(choice) || !isRecord(choice.message)) {
+      continue;
+    }
+
+    const message = choice.message;
+    collectUrlsFromMessageImages(message.images, imageUrls);
+    collectUrlsFromMessageContent(message.content, imageUrls);
+    collectUrlsFromToolCalls(message.toolCalls, imageUrls);
+    collectUrlsFromToolCalls(message.tool_calls, imageUrls);
+  }
+
+  collectUrlsFromResponsesOutput(response.output, imageUrls);
+  return Array.from(imageUrls);
 }
 
 function blobToDataUrl(blob: Blob): Promise<string> {
@@ -126,14 +261,7 @@ export function createOpenRouterAdapter(getConfig: () => OpenRouterConfig): Prov
             signal,
           });
 
-          const imageUrls: string[] = [];
-          for (const choice of response.choices ?? []) {
-            for (const image of choice.message.images ?? []) {
-              if (image.imageUrl?.url) {
-                imageUrls.push(image.imageUrl.url);
-              }
-            }
-          }
+          const imageUrls = collectImageUrlsFromChatResponse(response);
 
           for (const url of imageUrls) {
             // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
## Summary
- extend OpenRouter image URL extraction to support multiple response shapes (`message.images`, image parts in `message.content`, and image-generation tool call outputs)
- keep image URL parsing tolerant of camelCase and snake_case field variants
- add targeted unit tests for the new extraction paths to prevent regressions

## Validation
- `npm test -- src/ai/__tests__/openrouter-provider.test.ts`
- `npm test`
- `npm run typecheck`

Resolves #25
