### PR TITLE
feat: add POE provider via OpenAI-compatible API

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
             <option value="openai">OpenAI</option>
             <option value="gemini">Gemini</option>
             <option value="openrouter">OpenRouter</option>
+            <option value="poe">POE</option>
           </select>
         </div>
         <div class="row">
@@ -166,6 +167,14 @@
           <input id="openrouterBaseUrl" type="text" value="https://openrouter.ai/api/v1" />
         </div>
         <div class="row">
+          <label for="poeApiKey">POE Key</label>
+          <input id="poeApiKey" type="password" autocomplete="off" placeholder="ppk_..." />
+        </div>
+        <div class="row">
+          <label for="poeBaseUrl">POE Base</label>
+          <input id="poeBaseUrl" type="text" value="https://api.poe.com/v1" />
+        </div>
+        <div class="row">
           <label for="aiOutputCount">张数</label>
           <input id="aiOutputCount" type="number" min="1" max="4" value="1" />
         </div>
@@ -180,6 +189,7 @@
             <option value="openai">OpenAI</option>
             <option value="gemini">Gemini</option>
             <option value="openrouter">OpenRouter</option>
+            <option value="poe">POE</option>
           </select>
         </div>
       </form>

--- a/src/__tests__/ai-ui-options.test.ts
+++ b/src/__tests__/ai-ui-options.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   GEMINI_MODEL_PRESET_BY_ID,
   OPENAI_MODEL_PRESETS,
+  POE_MODEL_PRESETS,
   OPENROUTER_MODEL_PRESETS,
   getProviderModelPresets,
   isImageSourceKind,
@@ -55,9 +56,16 @@ describe("ai ui options", () => {
     ]);
   });
 
+  it("contains POE image model presets", () => {
+    expect(POE_MODEL_PRESETS.map((item) => item.model)).toEqual([
+      "GPT-Image-1",
+    ]);
+  });
+
   it("returns model presets by provider", () => {
     expect(getProviderModelPresets("openai")[0]?.model).toBe("gpt-image-1.5");
     expect(getProviderModelPresets("gemini")[0]?.model).toBe("gemini-2.5-flash-image");
     expect(getProviderModelPresets("openrouter")[0]?.model).toBe("openrouter/auto");
+    expect(getProviderModelPresets("poe")[0]?.model).toBe("GPT-Image-1");
   });
 });

--- a/src/ai/__tests__/poe-provider.test.ts
+++ b/src/ai/__tests__/poe-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   collectImageUrlsFromPoeResponse,
+  createPoeRequestHeaders,
   normalizePoeBaseUrl,
 } from "../providers/poe";
 
@@ -35,5 +36,17 @@ describe("collectImageUrlsFromPoeResponse", () => {
       "https://example.com/a.png",
       "https://example.com/b.png",
     ]);
+  });
+});
+
+describe("createPoeRequestHeaders", () => {
+  it("only includes authorization and content-type for CORS-safe browser calls", () => {
+    const headers = createPoeRequestHeaders("test_key");
+
+    expect(headers).toEqual({
+      Authorization: "Bearer test_key",
+      "Content-Type": "application/json",
+    });
+    expect(Object.keys(headers).some((key) => key.toLowerCase().startsWith("x-stainless"))).toBe(false);
   });
 });

--- a/src/ai/__tests__/poe-provider.test.ts
+++ b/src/ai/__tests__/poe-provider.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectImageUrlsFromPoeResponse,
+  normalizePoeBaseUrl,
+} from "../providers/poe";
+
+describe("normalizePoeBaseUrl", () => {
+  it("uses canonical /v1 path", () => {
+    expect(normalizePoeBaseUrl("https://api.poe.com")).toBe("https://api.poe.com/v1");
+  });
+
+  it("keeps explicit /v1 unchanged", () => {
+    expect(normalizePoeBaseUrl("https://api.poe.com/v1")).toBe("https://api.poe.com/v1");
+  });
+});
+
+describe("collectImageUrlsFromPoeResponse", () => {
+  it("extracts image URLs from content parts", () => {
+    const urls = collectImageUrlsFromPoeResponse({
+      choices: [
+        {
+          message: {
+            content: [
+              { type: "text", text: "ok" },
+              { type: "image_url", image_url: { url: "https://example.com/a.png" } },
+              { type: "output_image", url: "https://example.com/b.png" },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(urls).toEqual([
+      "https://example.com/a.png",
+      "https://example.com/b.png",
+    ]);
+  });
+});

--- a/src/ai/__tests__/provider-router.test.ts
+++ b/src/ai/__tests__/provider-router.test.ts
@@ -8,7 +8,9 @@ function makeRequest(provider: ProviderId): GenerateRequest {
     ? "gemini"
     : provider === "gemini"
       ? "openrouter"
-      : "openai";
+      : provider === "openrouter"
+        ? "poe"
+        : "openai";
   return {
     provider,
     mode: "text_to_image",
@@ -50,6 +52,12 @@ describe("runWithFallback", () => {
         return [makeAsset("openrouter")];
       },
     };
+    const poe: ProviderAdapter = {
+      generate: async () => {
+        calls.push("poe");
+        return [makeAsset("poe")];
+      },
+    };
 
     const result = await runWithFallback(
       makeRequest("openrouter"),
@@ -57,6 +65,7 @@ describe("runWithFallback", () => {
         openai,
         gemini,
         openrouter,
+        poe,
       },
       undefined,
     );
@@ -85,8 +94,14 @@ describe("runWithFallback", () => {
         return [makeAsset("openrouter")];
       },
     };
+    const poe: ProviderAdapter = {
+      generate: async () => {
+        calls.push("poe");
+        return [makeAsset("poe")];
+      },
+    };
 
-    const result = await runWithFallback(makeRequest("openai"), { openai, gemini, openrouter });
+    const result = await runWithFallback(makeRequest("openai"), { openai, gemini, openrouter, poe });
 
     expect(result.providerUsed).toBe("openai");
     expect(result.fallbackFrom).toBeNull();
@@ -114,8 +129,14 @@ describe("runWithFallback", () => {
         return [makeAsset("openrouter")];
       },
     };
+    const poe: ProviderAdapter = {
+      generate: async () => {
+        calls.push("poe");
+        return [makeAsset("poe")];
+      },
+    };
 
-    const result = await runWithFallback(makeRequest("openai"), { openai, gemini, openrouter });
+    const result = await runWithFallback(makeRequest("openai"), { openai, gemini, openrouter, poe });
 
     expect(result.providerUsed).toBe("gemini");
     expect(result.fallbackFrom).toBe("openai");
@@ -134,6 +155,9 @@ describe("runWithFallback", () => {
     const openrouter: ProviderAdapter = {
       generate: async () => [makeAsset("openrouter")],
     };
+    const poe: ProviderAdapter = {
+      generate: async () => [makeAsset("poe")],
+    };
 
     await expect(
       runWithFallback(
@@ -141,8 +165,50 @@ describe("runWithFallback", () => {
           ...makeRequest("openai"),
           fallbackProvider: undefined,
         },
-        { openai, gemini, openrouter },
+        { openai, gemini, openrouter, poe },
       ),
     ).rejects.toThrow("primary failed");
+  });
+
+  it("routes poe primary requests to the poe adapter", async () => {
+    const calls: string[] = [];
+    const openai: ProviderAdapter = {
+      generate: async () => {
+        calls.push("openai");
+        return [makeAsset("openai")];
+      },
+    };
+    const gemini: ProviderAdapter = {
+      generate: async () => {
+        calls.push("gemini");
+        return [makeAsset("gemini")];
+      },
+    };
+    const openrouter: ProviderAdapter = {
+      generate: async () => {
+        calls.push("openrouter");
+        return [makeAsset("openrouter")];
+      },
+    };
+    const poe: ProviderAdapter = {
+      generate: async () => {
+        calls.push("poe");
+        return [makeAsset("poe")];
+      },
+    };
+
+    const result = await runWithFallback(
+      makeRequest("poe"),
+      {
+        openai,
+        gemini,
+        openrouter,
+        poe,
+      },
+      undefined,
+    );
+
+    expect(result.providerUsed).toBe("poe");
+    expect(calls).toEqual(["poe"]);
   });
 });

--- a/src/ai/__tests__/request-config.test.ts
+++ b/src/ai/__tests__/request-config.test.ts
@@ -33,6 +33,16 @@ describe("resolveFallbackProvider", () => {
     expect(fallback).toBe("openrouter");
   });
 
+  it("supports poe as explicit fallback provider", () => {
+    const fallback = resolveFallbackProvider({
+      primaryProvider: "gemini",
+      enableFallback: true,
+      fallbackProvider: "poe",
+    });
+
+    expect(fallback).toBe("poe");
+  });
+
   it("returns undefined when fallback is disabled", () => {
     const fallback = resolveFallbackProvider({
       primaryProvider: "openai",

--- a/src/ai/provider-router.ts
+++ b/src/ai/provider-router.ts
@@ -6,6 +6,8 @@ function getAdapter(provider: ProviderId, adapters: ProviderAdapterMap) {
       return adapters.openai;
     case "gemini":
       return adapters.gemini;
+    case "poe":
+      return adapters.poe;
     default:
       return adapters.openrouter;
   }

--- a/src/ai/providers/poe.ts
+++ b/src/ai/providers/poe.ts
@@ -1,5 +1,3 @@
-import OpenAI, { APIError } from "openai";
-
 import { dataUrlToBlob, makeGeneratedAsset } from "../image-utils";
 import type { GenerateRequest, ProviderAdapter } from "../types";
 
@@ -25,6 +23,13 @@ export function normalizePoeBaseUrl(baseUrl: string): string {
     return noTrailingSlash;
   }
   return `${noTrailingSlash}/v1`;
+}
+
+export function createPoeRequestHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
 }
 
 function buildPromptText(req: GenerateRequest): string {
@@ -140,10 +145,61 @@ async function blobToDataUrl(blob: Blob): Promise<string> {
   });
 }
 
-function toPoeError(error: unknown): Error {
-  if (error instanceof APIError) {
-    return new Error(`POE request failed (${error.status ?? "unknown"}): ${error.message}`);
+function extractPoeErrorMessage(body: unknown): string | undefined {
+  if (!isRecord(body)) {
+    return undefined;
   }
+  if (isRecord(body.error)) {
+    const nested = toNonEmptyString(body.error.message);
+    if (nested) {
+      return nested;
+    }
+  }
+  return toNonEmptyString(body.message);
+}
+
+async function callPoeChatCompletions(
+  baseUrl: string,
+  apiKey: string,
+  model: string,
+  content: PoeUserContent,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const endpoint = `${normalizePoeBaseUrl(baseUrl)}/chat/completions`;
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: createPoeRequestHeaders(apiKey),
+    body: JSON.stringify({
+      model,
+      messages: [
+        {
+          role: "user",
+          content,
+        },
+      ],
+      stream: false,
+    }),
+    signal,
+  });
+
+  const text = await response.text();
+  let parsed: unknown = {};
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = { message: text };
+    }
+  }
+
+  if (!response.ok) {
+    const message = extractPoeErrorMessage(parsed) ?? `HTTP ${response.status}`;
+    throw new Error(`POE request failed (${response.status}): ${message}`);
+  }
+  return parsed;
+}
+
+function toPoeError(error: unknown): Error {
   if (error instanceof Error) {
     return new Error(`POE request failed: ${error.message}`);
   }
@@ -158,12 +214,6 @@ export function createPoeAdapter(getConfig: () => PoeConfig): ProviderAdapter {
       if (!apiKey) {
         throw new Error("Missing POE API key");
       }
-
-      const client = new OpenAI({
-        apiKey,
-        baseURL: normalizePoeBaseUrl(config.baseUrl || "https://api.poe.com"),
-        dangerouslyAllowBrowser: true,
-      });
 
       const prompt = buildPromptText(req);
       const runs = Math.max(1, req.outputCount);
@@ -187,18 +237,13 @@ export function createPoeAdapter(getConfig: () => PoeConfig): ProviderAdapter {
             : prompt;
 
           // eslint-disable-next-line no-await-in-loop
-          const response = await client.chat.completions.create({
-            model: req.model,
-            messages: [
-              {
-                role: "user",
-                content,
-              },
-            ],
-            stream: false,
-          }, {
+          const response = await callPoeChatCompletions(
+            config.baseUrl || "https://api.poe.com",
+            apiKey,
+            req.model,
+            content,
             signal,
-          });
+          );
 
           const imageUrls = collectImageUrlsFromPoeResponse(response);
           for (const url of imageUrls) {

--- a/src/ai/providers/poe.ts
+++ b/src/ai/providers/poe.ts
@@ -1,0 +1,232 @@
+import OpenAI, { APIError } from "openai";
+
+import { dataUrlToBlob, makeGeneratedAsset } from "../image-utils";
+import type { GenerateRequest, ProviderAdapter } from "../types";
+
+export interface PoeConfig {
+  apiKey: string;
+  baseUrl: string;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+type PoeUserContent = string | Array<
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } }
+>;
+
+export function normalizePoeBaseUrl(baseUrl: string): string {
+  const trimmed = (baseUrl || "https://api.poe.com").trim();
+  const noTrailingSlash = trimmed.replace(/\/+$/, "");
+  if (!noTrailingSlash) {
+    return "https://api.poe.com/v1";
+  }
+  if (/\/v1$/i.test(noTrailingSlash)) {
+    return noTrailingSlash;
+  }
+  return `${noTrailingSlash}/v1`;
+}
+
+function buildPromptText(req: GenerateRequest): string {
+  if (!req.negativePrompt) {
+    return req.prompt;
+  }
+  return `${req.prompt}\n\nNegative prompt: ${req.negativePrompt}`;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return value !== null && typeof value === "object";
+}
+
+function toNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readUrlFromUnknown(value: unknown): string | undefined {
+  const direct = toNonEmptyString(value);
+  if (direct) {
+    return direct;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const url = toNonEmptyString(value.url);
+  if (url) {
+    return url;
+  }
+
+  const nestedSnake = readUrlFromUnknown(value.image_url);
+  if (nestedSnake) {
+    return nestedSnake;
+  }
+  return readUrlFromUnknown(value.imageUrl);
+}
+
+export function collectImageUrlsFromPoeResponse(response: unknown): string[] {
+  if (!isRecord(response)) {
+    return [];
+  }
+
+  const imageUrls = new Set<string>();
+  const choices = Array.isArray(response.choices) ? response.choices : [];
+  for (const choice of choices) {
+    if (!isRecord(choice) || !isRecord(choice.message)) {
+      continue;
+    }
+
+    const message = choice.message;
+    if (Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (!isRecord(part)) {
+          continue;
+        }
+        const partType = toNonEmptyString(part.type);
+        if (partType && !partType.includes("image")) {
+          continue;
+        }
+        const url =
+          readUrlFromUnknown(part.image_url)
+          ?? readUrlFromUnknown(part.imageUrl)
+          ?? readUrlFromUnknown(part.url)
+          ?? readUrlFromUnknown(part.result);
+        if (url) {
+          imageUrls.add(url);
+        }
+      }
+    }
+
+    if (Array.isArray(message.images)) {
+      for (const image of message.images) {
+        const url = readUrlFromUnknown(image);
+        if (url) {
+          imageUrls.add(url);
+        }
+      }
+    }
+  }
+
+  return Array.from(imageUrls);
+}
+
+async function imageUrlToBlob(url: string): Promise<Blob> {
+  if (url.startsWith("data:")) {
+    return dataUrlToBlob(url);
+  }
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`POE image URL download failed (${response.status})`);
+  }
+  return await response.blob();
+}
+
+async function blobToDataUrl(blob: Blob): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(new Error("Failed to read image source"));
+      }
+    };
+    reader.onerror = () => reject(new Error("Failed to read image source"));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function toPoeError(error: unknown): Error {
+  if (error instanceof APIError) {
+    return new Error(`POE request failed (${error.status ?? "unknown"}): ${error.message}`);
+  }
+  if (error instanceof Error) {
+    return new Error(`POE request failed: ${error.message}`);
+  }
+  return new Error("POE request failed");
+}
+
+export function createPoeAdapter(getConfig: () => PoeConfig): ProviderAdapter {
+  return {
+    async generate(req: GenerateRequest, signal?: AbortSignal) {
+      const config = getConfig();
+      const apiKey = config.apiKey.trim();
+      if (!apiKey) {
+        throw new Error("Missing POE API key");
+      }
+
+      const client = new OpenAI({
+        apiKey,
+        baseURL: normalizePoeBaseUrl(config.baseUrl || "https://api.poe.com"),
+        dangerouslyAllowBrowser: true,
+      });
+
+      const prompt = buildPromptText(req);
+      const runs = Math.max(1, req.outputCount);
+      const blobs: Blob[] = [];
+
+      try {
+        let sourceImageDataUrl: string | undefined;
+        if (req.mode === "image_to_image") {
+          if (!req.imageSource) {
+            throw new Error("Image source is required for image-to-image mode");
+          }
+          sourceImageDataUrl = await blobToDataUrl(req.imageSource.blob);
+        }
+
+        for (let i = 0; i < runs; i++) {
+          const content: PoeUserContent = sourceImageDataUrl
+            ? [
+              { type: "text", text: prompt },
+              { type: "image_url", image_url: { url: sourceImageDataUrl } },
+            ]
+            : prompt;
+
+          // eslint-disable-next-line no-await-in-loop
+          const response = await client.chat.completions.create({
+            model: req.model,
+            messages: [
+              {
+                role: "user",
+                content,
+              },
+            ],
+            stream: false,
+          }, {
+            signal,
+          });
+
+          const imageUrls = collectImageUrlsFromPoeResponse(response);
+          for (const url of imageUrls) {
+            // eslint-disable-next-line no-await-in-loop
+            const blob = await imageUrlToBlob(url);
+            blobs.push(blob);
+            if (blobs.length >= runs) {
+              break;
+            }
+          }
+          if (blobs.length >= runs) {
+            break;
+          }
+        }
+      } catch (error) {
+        throw toPoeError(error);
+      }
+
+      if (blobs.length === 0) {
+        throw new Error("POE returned no images");
+      }
+
+      const assets = [];
+      for (const blob of blobs) {
+        // eslint-disable-next-line no-await-in-loop
+        assets.push(await makeGeneratedAsset(blob));
+      }
+      return assets;
+    },
+  };
+}

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,4 +1,4 @@
-export type ProviderId = "openai" | "gemini" | "openrouter";
+export type ProviderId = "openai" | "gemini" | "openrouter" | "poe";
 
 export type GenerationMode = "text_to_image" | "image_to_image";
 
@@ -56,6 +56,7 @@ export interface ProviderAdapterMap {
   openai: ProviderAdapter;
   gemini: ProviderAdapter;
   openrouter: ProviderAdapter;
+  poe: ProviderAdapter;
 }
 
 export interface RunWithFallbackResult {
@@ -77,6 +78,9 @@ export interface AiSettings {
   openrouterApiKey: string;
   openrouterBaseUrl: string;
   openrouterModel: string;
+  poeApiKey: string;
+  poeBaseUrl: string;
+  poeModel: string;
   enableFallback: boolean;
   fallbackProvider: "" | ProviderId;
   outputCount: number;

--- a/src/ai/ui-options.ts
+++ b/src/ai/ui-options.ts
@@ -89,6 +89,14 @@ export const OPENROUTER_MODEL_PRESETS: ProviderModelPreset[] = [
   },
 ];
 
+export const POE_MODEL_PRESETS: ProviderModelPreset[] = [
+  {
+    id: "poe_gpt_image_1",
+    label: "GPT-Image-1",
+    model: "GPT-Image-1",
+  },
+];
+
 export function isImageSourceKind(value: string): value is ImageSourceKind {
   return value === "crop" || value === "active_layer" || value === "gallery_item" || value === "uploaded_file";
 }
@@ -103,6 +111,9 @@ export function getProviderModelPresets(provider: ProviderId): ProviderModelPres
   }
   if (provider === "openrouter") {
     return OPENROUTER_MODEL_PRESETS;
+  }
+  if (provider === "poe") {
+    return POE_MODEL_PRESETS;
   }
   return OPENAI_MODEL_PRESETS;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import { createTaskRecord, patchTaskRecord } from "./ai/task-store";
 import { createGeminiAdapter } from "./ai/providers/gemini";
 import { createOpenAIAdapter } from "./ai/providers/openai";
 import { createOpenRouterAdapter } from "./ai/providers/openrouter";
+import { createPoeAdapter } from "./ai/providers/poe";
 import {
   getProviderModelPresets,
   isImageSourceKind,
@@ -210,6 +211,9 @@ const DEFAULT_AI_SETTINGS: AiSettings = {
   openrouterApiKey: "",
   openrouterBaseUrl: "https://openrouter.ai/api/v1",
   openrouterModel: "openai/gpt-5-image",
+  poeApiKey: "",
+  poeBaseUrl: "https://api.poe.com/v1",
+  poeModel: "GPT-Image-1",
   enableFallback: true,
   fallbackProvider: "",
   outputCount: 1,
@@ -353,6 +357,8 @@ const geminiApiKeyInput = mustGet<HTMLInputElement>("geminiApiKey");
 const geminiBaseUrlInput = mustGet<HTMLInputElement>("geminiBaseUrl");
 const openrouterApiKeyInput = mustGet<HTMLInputElement>("openrouterApiKey");
 const openrouterBaseUrlInput = mustGet<HTMLInputElement>("openrouterBaseUrl");
+const poeApiKeyInput = mustGet<HTMLInputElement>("poeApiKey");
+const poeBaseUrlInput = mustGet<HTMLInputElement>("poeBaseUrl");
 const aiOutputCountInput = mustGet<HTMLInputElement>("aiOutputCount");
 const enableFallbackInput = mustGet<HTMLInputElement>("enableFallback");
 const fallbackProviderSelect = mustGet<HTMLSelectElement>("fallbackProvider");
@@ -1932,7 +1938,7 @@ function downloadBlob(blob: Blob, filename: string): void {
 }
 
 function isProviderId(value: string): value is ProviderId {
-  return value === "openai" || value === "gemini" || value === "openrouter";
+  return value === "openai" || value === "gemini" || value === "openrouter" || value === "poe";
 }
 
 function isGenerationMode(value: string): value is GenerationMode {
@@ -1949,6 +1955,9 @@ function getProviderModel(provider: ProviderId): string {
   }
   if (provider === "openrouter") {
     return aiState.settings.openrouterModel;
+  }
+  if (provider === "poe") {
+    return aiState.settings.poeModel;
   }
   return aiState.settings.openaiModel;
 }
@@ -1968,6 +1977,10 @@ function setProviderModel(provider: ProviderId, model: string): void {
   }
   if (provider === "openrouter") {
     aiState.settings.openrouterModel = normalizeModelForProvider(provider, model) || DEFAULT_AI_SETTINGS.openrouterModel;
+    return;
+  }
+  if (provider === "poe") {
+    aiState.settings.poeModel = normalizeModelForProvider(provider, model) || DEFAULT_AI_SETTINGS.poeModel;
     return;
   }
   aiState.settings.openaiModel = normalizeModelForProvider(provider, model) || DEFAULT_AI_SETTINGS.openaiModel;
@@ -2026,7 +2039,10 @@ function loadAiSettings(): void {
       preferredSourceKind: normalizedPreferredSourceKind,
       geminiModel: normalizeGeminiModelId(parsed.geminiModel ?? DEFAULT_AI_SETTINGS.geminiModel),
       outputCount: clamp(Number(parsed.outputCount ?? DEFAULT_AI_SETTINGS.outputCount), 1, 4),
-      fallbackProvider: parsed.fallbackProvider === "openai" || parsed.fallbackProvider === "gemini" || parsed.fallbackProvider === "openrouter"
+      fallbackProvider: parsed.fallbackProvider === "openai"
+        || parsed.fallbackProvider === "gemini"
+        || parsed.fallbackProvider === "openrouter"
+        || parsed.fallbackProvider === "poe"
         ? parsed.fallbackProvider
         : "",
     };
@@ -2053,6 +2069,8 @@ function syncAiSettingsToUI(): void {
   geminiBaseUrlInput.value = aiState.settings.geminiBaseUrl;
   openrouterApiKeyInput.value = aiState.settings.openrouterApiKey;
   openrouterBaseUrlInput.value = aiState.settings.openrouterBaseUrl;
+  poeApiKeyInput.value = aiState.settings.poeApiKey;
+  poeBaseUrlInput.value = aiState.settings.poeBaseUrl;
   aiOutputCountInput.value = String(aiState.settings.outputCount);
   enableFallbackInput.checked = aiState.settings.enableFallback;
   fallbackProviderSelect.value = aiState.settings.fallbackProvider;
@@ -2069,6 +2087,8 @@ function syncAiSettingsFromUI(): void {
   aiState.settings.geminiBaseUrl = geminiBaseUrlInput.value.trim() || DEFAULT_AI_SETTINGS.geminiBaseUrl;
   aiState.settings.openrouterApiKey = openrouterApiKeyInput.value.trim();
   aiState.settings.openrouterBaseUrl = openrouterBaseUrlInput.value.trim() || DEFAULT_AI_SETTINGS.openrouterBaseUrl;
+  aiState.settings.poeApiKey = poeApiKeyInput.value.trim();
+  aiState.settings.poeBaseUrl = poeBaseUrlInput.value.trim() || DEFAULT_AI_SETTINGS.poeBaseUrl;
   const provider = aiState.settings.activeProvider;
   const presets = modelPresetsForProvider(provider);
   const selectedPresetId = aiModelPresetSelect.value;
@@ -2270,6 +2290,11 @@ const geminiAdapter = createGeminiAdapter(() => ({
 const openrouterAdapter = createOpenRouterAdapter(() => ({
   apiKey: aiState.settings.openrouterApiKey,
   baseUrl: aiState.settings.openrouterBaseUrl,
+}));
+
+const poeAdapter = createPoeAdapter(() => ({
+  apiKey: aiState.settings.poeApiKey,
+  baseUrl: aiState.settings.poeBaseUrl,
 }));
 
 function refreshOutputDirStatus(): void {
@@ -2574,7 +2599,9 @@ async function createGenerateRequestFromUI(): Promise<GenerateRequest> {
     ? aiState.settings.openaiModel
     : provider === "gemini"
       ? aiState.settings.geminiModel
-      : aiState.settings.openrouterModel;
+      : provider === "openrouter"
+        ? aiState.settings.openrouterModel
+        : aiState.settings.poeModel;
   const request = makeProviderRequest({
     provider,
     mode,
@@ -2607,7 +2634,7 @@ async function runGenerateTask(request: GenerateRequest): Promise<void> {
   try {
     const result = await runWithFallback(
       request,
-      { openai: openaiAdapter, gemini: geminiAdapter, openrouter: openrouterAdapter },
+      { openai: openaiAdapter, gemini: geminiAdapter, openrouter: openrouterAdapter, poe: poeAdapter },
       controller.signal,
     );
     const outputFiles: string[] = [];
@@ -3102,6 +3129,8 @@ aiSettingsModal.addEventListener("click", (event) => {
   geminiBaseUrlInput,
   openrouterApiKeyInput,
   openrouterBaseUrlInput,
+  poeApiKeyInput,
+  poeBaseUrlInput,
   aiOutputCountInput,
   enableFallbackInput,
   fallbackProviderSelect,


### PR DESCRIPTION
## Summary
- add a dedicated `poe` provider (OpenAI-compatible) with default base URL `https://api.poe.com/v1`
- add POE provider settings in UI (`POE Key`, `POE Base`) and provider/fallback selectors
- implement Poe adapter using browser `fetch` chat completions calls (avoids `x-stainless-*` headers that fail Poe CORS preflight)
- extend provider routing, model preset options, and fallback parsing to support `poe`
- add tests for Poe URL normalization/extraction and CORS-safe header generation

## Validation
- `npm run typecheck`
- `npm test`

Resolves #29
